### PR TITLE
Remove outdated DataPackage keys

### DIFF
--- a/Archipelago.MultiClient.Net/Models/DataPackage.cs
+++ b/Archipelago.MultiClient.Net/Models/DataPackage.cs
@@ -8,12 +8,6 @@ namespace Archipelago.MultiClient.Net.Models
 {
     public class DataPackage
     {
-        [JsonProperty("lookup_any_location_id_to_name")]
-        public Dictionary<int, string> LocationLookup { get; set; }
-
-        [JsonProperty("lookup_any_item_id_to_name")]
-        public Dictionary<int, string> ItemLookup { get; set; }
-
         [JsonProperty("version")]
         public int Version { get; set; }
 


### PR DESCRIPTION
lookup_any_location_id_to_name and lookup_any_item_id_to_name will be removed as per https://github.com/ArchipelagoMW/Archipelago/pull/86
Merging here may want to wait until that's merged.