### PR TITLE
Prevent returning null data package if data package cache is empty

### DIFF
--- a/Archipelago.MultiClient.Net/Cache/FileSystemDataPackageProvider.cs
+++ b/Archipelago.MultiClient.Net/Cache/FileSystemDataPackageProvider.cs
@@ -29,7 +29,7 @@ namespace Archipelago.MultiClient.Net.Cache
                     {
                         string fileText = File.ReadAllText(dataPackagePath);
                         package = JsonConvert.DeserializeObject<DataPackage>(fileText);
-                        return true;
+                        return package != null;
                     }
                 }
                 catch


### PR DESCRIPTION
Noticed that if the `datapackagecache.archipelagocache` file is empty (for some reason), when `FileSystemDataPackageProvider.TryGetPackage` would de-serialize the file, it would return `true` and have `null` as its output variable and thus, would not rebuild the data package cache. Adding a final check here prevents that from happening.

Ran a test with an empty data package cache file in Rogue Legacy and it would crash when searching for an item name in the cache (as it's `null`) and would not rebuild cache. After this fix, it rebuilt the data package cache and Rogue Legacy would not crash.

Discord context for troubleshooting: https://discord.com/channels/731205301247803413/763938462092886067/975906314179981332