### PR TITLE
Made deathlink toggleable

### DIFF
--- a/Archipelago.MultiClient.Net.Tests/DeathLinkFixture.cs
+++ b/Archipelago.MultiClient.Net.Tests/DeathLinkFixture.cs
@@ -151,7 +151,7 @@ namespace Archipelago.MultiClient.Net.Tests
 
             var sut = new DeathLinkService(socket, connectionInfo, new DataStorageHelper(socket, connectionInfo));
 
-            sut.EnabledDeathLink();
+            sut.EnableDeathLink();
 
             socket.Received().SendPacket(Arg.Is<ConnectUpdatePacket>(p => p.Tags.Length == 1 && p.Tags[0] == "DeathLink"));
             
@@ -169,7 +169,7 @@ namespace Archipelago.MultiClient.Net.Tests
 
             var sut = new DeathLinkService(socket, connectionInfo, new DataStorageHelper(socket, connectionInfo));
 
-            sut.EnabledDeathLink();
+            sut.EnableDeathLink();
 
             socket.DidNotReceive().SendPacket(Arg.Any<ConnectUpdatePacket>());
 

--- a/Archipelago.MultiClient.Net.Tests/DeathLinkFixture.cs
+++ b/Archipelago.MultiClient.Net.Tests/DeathLinkFixture.cs
@@ -1,6 +1,7 @@
 ﻿using Archipelago.MultiClient.Net.BounceFeatures.DeathLink;
 using Archipelago.MultiClient.Net.Converters;
 using Archipelago.MultiClient.Net.Helpers;
+using Archipelago.MultiClient.Net.Packets;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NSubstitute;
@@ -102,6 +103,114 @@ namespace Archipelago.MultiClient.Net.Tests
             Assert.That(deathLink.Timestamp, Is.EqualTo(expectedDeathLink.Timestamp));
             Assert.That(deathLink.Source, Is.EqualTo(expectedDeathLink.Source));
             Assert.That(deathLink.Cause, Is.EqualTo(expectedDeathLink.Cause));
+        }
+
+        public static TestCaseData[] NotOwnDeathLinkTests =>
+            new[] {
+                new TestCaseData(new DeathLink("TestPlayer")),
+                new TestCaseData(new DeathLink("TestPlayer", "Yolo'ed"))
+            };
+
+        [TestCaseSource(nameof(NotOwnDeathLinkTests))]
+        public void Should_not_trigger_of_own_death_link(DeathLink deathLink)
+        {
+            var socket = Substitute.For<IArchipelagoSocketHelper>();
+            var connectionInfo = Substitute.For<IConnectionInfoProvider>();
+
+            var sut = new DeathLinkService(socket, connectionInfo, new DataStorageHelper(socket, connectionInfo));
+
+            DeathLink receivedDeathLink = null;
+            sut.OnDeathLinkReceived += dl =>
+            {
+                receivedDeathLink = dl;
+            };
+
+            sut.SendDeathLink(deathLink);
+
+            var bouncePacket = new BouncedPacket {
+                Tags = new List<string> { "DeathLink" },
+                Data = new Dictionary<string, JToken> {
+                    { "source", deathLink.Source },
+                    { "time", deathLink.Timestamp.ToUnixTimeStamp() },
+                    { "cause", deathLink.Cause } 
+                }
+            };
+
+            socket.PacketReceived += Raise.Event<ArchipelagoSocketHelperDelagates.PacketReceivedHandler>(bouncePacket);
+
+            Assert.That(receivedDeathLink, Is.Null);
+        }
+
+        [Test]
+        public void Should_enable_death_link_if_its_not_enabled()
+        {
+            var socket = Substitute.For<IArchipelagoSocketHelper>();
+            var connectionInfo = new ConnectionInfoHelper(socket);
+
+            connectionInfo.Tags = Array.Empty<string>();
+
+            var sut = new DeathLinkService(socket, connectionInfo, new DataStorageHelper(socket, connectionInfo));
+
+            sut.EnabledDeathLink();
+
+            socket.Received().SendPacket(Arg.Is<ConnectUpdatePacket>(p => p.Tags.Length == 1 && p.Tags[0] == "DeathLink"));
+            
+            Assert.That(connectionInfo.Tags.Length, Is.EqualTo(1));
+            Assert.That(connectionInfo.Tags[0], Is.EqualTo("DeathLink"));
+        }
+
+        [Test] 
+        public void Should_enable_death_link_if_its_already_enabled()
+        {
+            var socket = Substitute.For<IArchipelagoSocketHelper>();
+            var connectionInfo = new ConnectionInfoHelper(socket);
+
+            connectionInfo.Tags = new[] { "DeathLink" };
+
+            var sut = new DeathLinkService(socket, connectionInfo, new DataStorageHelper(socket, connectionInfo));
+
+            sut.EnabledDeathLink();
+
+            socket.DidNotReceive().SendPacket(Arg.Any<ConnectUpdatePacket>());
+
+            Assert.That(connectionInfo.Tags.Length, Is.EqualTo(1));
+            Assert.That(connectionInfo.Tags[0], Is.EqualTo("DeathLink"));
+        }
+
+        [Test]
+        public void Should_disabled_death_link_if_its_not_enabled()
+        {
+            var socket = Substitute.For<IArchipelagoSocketHelper>();
+            var connectionInfo = new ConnectionInfoHelper(socket);
+
+            connectionInfo.Tags = new[] { "SomeTag" };
+
+            var sut = new DeathLinkService(socket, connectionInfo, new DataStorageHelper(socket, connectionInfo));
+
+            sut.DisableDeathLink();
+
+            socket.DidNotReceive().SendPacket(Arg.Any<ConnectUpdatePacket>());
+
+            Assert.That(connectionInfo.Tags.Length, Is.EqualTo(1));
+            Assert.That(connectionInfo.Tags[0], Is.EqualTo("SomeTag"));
+        }
+
+        [Test]
+        public void Should_disable_death_link_if_its_already_enabled()
+        {
+            var socket = Substitute.For<IArchipelagoSocketHelper>();
+            var connectionInfo = new ConnectionInfoHelper(socket);
+
+            connectionInfo.Tags = new[] { "SomeTag", "DeathLink" };
+
+            var sut = new DeathLinkService(socket, connectionInfo, new DataStorageHelper(socket, connectionInfo));
+
+            sut.DisableDeathLink();
+
+            socket.Received().SendPacket(Arg.Is<ConnectUpdatePacket>(p => p.Tags.Length == 1 && p.Tags[0] == "SomeTag"));
+
+            Assert.That(connectionInfo.Tags.Length, Is.EqualTo(1));
+            Assert.That(connectionInfo.Tags[0], Is.EqualTo("SomeTag"));
         }
     }
 }

--- a/Archipelago.MultiClient.Net/ArchipelagoSession.cs
+++ b/Archipelago.MultiClient.Net/ArchipelagoSession.cs
@@ -139,21 +139,5 @@ namespace Archipelago.MultiClient.Net
                 return new LoginFailure("Socket closed unexpectedly.");
             }
         }
-
-        /// <summary>
-        ///     Send a ConnectUpdate packet and set the tags and ItemsHandlingFlags for the current connection to the provided params.
-        /// </summary>
-        /// <param name="tags">New tags for the current connection.</param>
-        /// <param name="itemsHandlingFlags">New ItemsHandlingFlags for the current connection.</param>
-        public void UpdateConnectionOptions(string[] tags, ItemsHandlingFlags itemsHandlingFlags)
-        {
-            ConnectionInfo.SetConnectionParameters(ConnectionInfo.Game, tags, itemsHandlingFlags, ConnectionInfo.Uuid);
-
-            Socket.SendPacket(new ConnectUpdatePacket
-            {
-                Tags = ConnectionInfo.Tags,
-                ItemsHandling = ConnectionInfo.ItemsHandlingFlags
-            });
-        }
     }
 }

--- a/Archipelago.MultiClient.Net/BounceFeatures/DeathLink/DeathLink.cs
+++ b/Archipelago.MultiClient.Net/BounceFeatures/DeathLink/DeathLink.cs
@@ -5,11 +5,11 @@ using System.Collections.Generic;
 
 namespace Archipelago.MultiClient.Net.BounceFeatures.DeathLink
 {
-    public class DeathLink
+    public class DeathLink : IEquatable<DeathLink>
     {
-        public DateTime Timestamp { get; set; }
-        public string Source { get; set; }
-        public string Cause { get; set; }
+        public DateTime Timestamp { get; internal set; }
+        public string Source { get; }
+        public string Cause { get; }
 
         public DeathLink(string sourcePlayer, string cause = null)
         {
@@ -44,6 +44,66 @@ namespace Archipelago.MultiClient.Net.BounceFeatures.DeathLink
                 deathLink = null;
                 return false;
             }
+        }
+
+        public bool Equals(DeathLink other)
+        {
+            if (ReferenceEquals(null, other))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return Source == other.Source
+                   && Timestamp.Date.Equals(other.Timestamp.Date)
+                   && Timestamp.Hour == other.Timestamp.Hour
+                   && Timestamp.Minute == other.Timestamp.Minute
+                   && Timestamp.Second == other.Timestamp.Second;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            if (obj.GetType() != GetType())
+            {
+                return false;
+            }
+
+            return Equals((DeathLink)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = Timestamp.GetHashCode();
+                hashCode = (hashCode * 397) ^ (Source != null ? Source.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (Cause != null ? Cause.GetHashCode() : 0);
+                return hashCode;
+            }
+        }
+
+        public static bool operator ==(DeathLink lhs, DeathLink rhs)
+        {
+            return lhs?.Equals(rhs) ?? rhs is null;
+        }
+
+        public static bool operator !=(DeathLink lhs, DeathLink rhs)
+        {
+            return !(lhs == rhs);
         }
     }
 }

--- a/Archipelago.MultiClient.Net/BounceFeatures/DeathLink/DeathLink.cs
+++ b/Archipelago.MultiClient.Net/BounceFeatures/DeathLink/DeathLink.cs
@@ -91,7 +91,6 @@ namespace Archipelago.MultiClient.Net.BounceFeatures.DeathLink
             {
                 var hashCode = Timestamp.GetHashCode();
                 hashCode = (hashCode * 397) ^ (Source != null ? Source.GetHashCode() : 0);
-                hashCode = (hashCode * 397) ^ (Cause != null ? Cause.GetHashCode() : 0);
                 return hashCode;
             }
         }

--- a/Archipelago.MultiClient.Net/BounceFeatures/DeathLink/DeathLinkProvider.cs
+++ b/Archipelago.MultiClient.Net/BounceFeatures/DeathLink/DeathLinkProvider.cs
@@ -7,25 +7,11 @@ namespace Archipelago.MultiClient.Net.BounceFeatures.DeathLink
     {
         // ReSharper disable once UnusedMember.Global
         /// <summary>
-        ///     Ensures the DeathLink tag is set with the session and then creates and returns a <see cref="DeathLinkService"/> for this <paramref name="session"/>.
+        ///     creates and returns a <see cref="DeathLinkService"/> for this <paramref name="session"/>.
         /// </summary>
-        public static DeathLinkService CreateDeathLinkServiceAndEnable(this ArchipelagoSession session)
+        public static DeathLinkService CreateDeathLinkService(this ArchipelagoSession session)
         {
-            EnsureDeathLinkTagIsSet(session);
-
             return new DeathLinkService(session.Socket, session.ConnectionInfo, session.DataStorage);
-        }
-
-        private static void EnsureDeathLinkTagIsSet(ArchipelagoSession session)
-        {
-            if (Array.IndexOf(session.ConnectionInfo.Tags, "DeathLink") == -1)
-            {
-                var newTags = new List<string>(session.ConnectionInfo.Tags.Length + 1);
-                newTags.AddRange(session.ConnectionInfo.Tags);
-                newTags.Add("DeathLink");
-
-                session.UpdateConnectionOptions(newTags.ToArray(), session.ConnectionInfo.ItemsHandlingFlags);
-            }
         }
     }
 }

--- a/Archipelago.MultiClient.Net/BounceFeatures/DeathLink/DeathLinkService.cs
+++ b/Archipelago.MultiClient.Net/BounceFeatures/DeathLink/DeathLinkService.cs
@@ -95,7 +95,7 @@ namespace Archipelago.MultiClient.Net.BounceFeatures.DeathLink
             socket.SendPacketAsync(bouncePacket);
         }
 
-        public void EnabledDeathLink()
+        public void EnableDeathLink()
         {
             if (Array.IndexOf(connectionInfoProvider.Tags, "DeathLink") == -1)
             {

--- a/Archipelago.MultiClient.Net/BounceFeatures/DeathLink/DeathLinkService.cs
+++ b/Archipelago.MultiClient.Net/BounceFeatures/DeathLink/DeathLinkService.cs
@@ -5,6 +5,7 @@ using Archipelago.MultiClient.Net.Packets;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Archipelago.MultiClient.Net.BounceFeatures.DeathLink
 {
@@ -13,6 +14,8 @@ namespace Archipelago.MultiClient.Net.BounceFeatures.DeathLink
         private readonly IArchipelagoSocketHelper socket;
         private readonly IConnectionInfoProvider connectionInfoProvider;
         private readonly DataStorageHelper logger;
+
+        private DeathLink lastSendDeathLink;
 
         public delegate void DeathLinkReceivedHandler(DeathLink deathLink);
         public event DeathLinkReceivedHandler OnDeathLinkReceived;
@@ -39,6 +42,11 @@ namespace Archipelago.MultiClient.Net.BounceFeatures.DeathLink
                     {
                         logger[Scope.Slot, "DeathLinkReceived"] += new [] { $"Parsed on {DateTime.UtcNow:u}: {JObject.FromObject(bouncedPacket)}" };
 
+                        if (lastSendDeathLink != null && lastSendDeathLink == deathLink)
+                        {
+                            return;
+                        }
+
                         if (OnDeathLinkReceived != null)
                         {
                             OnDeathLinkReceived(deathLink);
@@ -47,8 +55,7 @@ namespace Archipelago.MultiClient.Net.BounceFeatures.DeathLink
                     else
                     {
                         logger[Scope.Slot, "DeathLinkReceived"] += new[] { $"Failed on {DateTime.UtcNow:u}: {JObject.FromObject(bouncedPacket)}" };
-                        logger["FailedDeathLinks"] 
-                            += new[] { $"Failed for slot {connectionInfoProvider.Slot} on {DateTime.UtcNow:u}: {JObject.FromObject(bouncedPacket)}" };
+                        logger["FailedDeathLinks"] += new[] { $"Failed for slot {connectionInfoProvider.Slot} on {DateTime.UtcNow:u}: {JObject.FromObject(bouncedPacket)}" };
                     }
                     break;
             }
@@ -70,8 +77,7 @@ namespace Archipelago.MultiClient.Net.BounceFeatures.DeathLink
             var bouncePacket = new BouncePacket
             {
                 Tags = new List<string> { "DeathLink" },
-                Data = new Dictionary<string, JToken>
-                {
+                Data = new Dictionary<string, JToken> {
                     {"time", deathLink.Timestamp.ToUnixTimeStamp()},
                     {"source", deathLink.Source},
                 }
@@ -84,7 +90,29 @@ namespace Archipelago.MultiClient.Net.BounceFeatures.DeathLink
 
             logger[Scope.Slot, "DeathLinkSend"] += new[] { $"Send on {DateTime.UtcNow:u}: {JObject.FromObject(bouncePacket)}" };
 
+            lastSendDeathLink = deathLink;
+
             socket.SendPacketAsync(bouncePacket);
+        }
+
+        public void EnabledDeathLink()
+        {
+            if (Array.IndexOf(connectionInfoProvider.Tags, "DeathLink") == -1)
+            {
+                connectionInfoProvider.UpdateConnectionOptions(
+                    connectionInfoProvider.Tags.Concat(new[] { "DeathLink" }).ToArray());
+            }
+        }
+
+        public void DisableDeathLink()
+        {
+            if (Array.IndexOf(connectionInfoProvider.Tags, "DeathLink") == -1)
+            {
+                return;
+            }
+
+            connectionInfoProvider.UpdateConnectionOptions(
+                connectionInfoProvider.Tags.Where(t => t != "DeathLink").ToArray());
         }
     }
 }

--- a/Archipelago.MultiClient.Net/Converters/UnixTimeConverter.cs
+++ b/Archipelago.MultiClient.Net/Converters/UnixTimeConverter.cs
@@ -4,20 +4,24 @@ namespace Archipelago.MultiClient.Net.Converters
 {
     public static class UnixTimeConverter
     {
+        private static DateTime UtcEpoch =>
+#if !NET6_0
+            new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
+#else
+            DateTime.UnixEpoch;
+#endif
+
         public static DateTime UnixTimeStampToDateTime(double unixTimeStamp)
         {
             if (unixTimeStamp > 1000000000000) //its a 64-bit unix timestamp
                 unixTimeStamp /= 1000;
 
-            var dateTime = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
-            dateTime = dateTime.AddSeconds(unixTimeStamp);
-            return dateTime;
+            return UtcEpoch.AddSeconds(unixTimeStamp);
         }
 
         public static double ToUnixTimeStamp(this DateTime dateTime)
         {
-            var utcEpoch = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
-            return (dateTime - utcEpoch).TotalMilliseconds / 1000;
+            return (dateTime - UtcEpoch).TotalMilliseconds / 1000;
         }
     }
 }

--- a/Archipelago.MultiClient.Net/Helpers/ConnectionInfoHelper.cs
+++ b/Archipelago.MultiClient.Net/Helpers/ConnectionInfoHelper.cs
@@ -30,10 +30,31 @@ namespace Archipelago.MultiClient.Net.Helpers
         /// The Uniquely Identifiable string under which you client is connected or an empty string otherwise
         /// </summary>
         string Uuid { get; }
+
+        /// <summary>
+        ///     Send a ConnectUpdate packet and set the tags and ItemsHandlingFlags for the current connection to the provided params.
+        /// </summary>
+        /// <param name="tags">New tags for the current connection.</param>
+        void UpdateConnectionOptions(string[] tags);
+
+        /// <summary>
+        ///     Send a ConnectUpdate packet and set the tags and ItemsHandlingFlags for the current connection to the provided params.
+        /// </summary>
+        /// <param name="itemsHandlingFlags">New ItemsHandlingFlags for the current connection.</param>
+        void UpdateConnectionOptions(ItemsHandlingFlags itemsHandlingFlags);
+
+        /// <summary>
+        ///     Send a ConnectUpdate packet and set the tags and ItemsHandlingFlags for the current connection to the provided params.
+        /// </summary>
+        /// <param name="tags">New tags for the current connection.</param>
+        /// <param name="itemsHandlingFlags">New ItemsHandlingFlags for the current connection.</param>
+        void UpdateConnectionOptions(string[] tags, ItemsHandlingFlags itemsHandlingFlags);
     }
 
     public class ConnectionInfoHelper : IConnectionInfoProvider
     {
+        private readonly IArchipelagoSocketHelper socket;
+
         public string Game { get; private set; }
         public int Team { get; private set; }
         public int Slot { get; private set; }
@@ -43,6 +64,8 @@ namespace Archipelago.MultiClient.Net.Helpers
 
         public ConnectionInfoHelper(IArchipelagoSocketHelper socket)
         {
+            this.socket = socket;
+
             Reset();
 
             socket.PacketReceived += PacketReceived;
@@ -78,6 +101,40 @@ namespace Archipelago.MultiClient.Net.Helpers
             Tags = new string[0];
             ItemsHandlingFlags = ItemsHandlingFlags.NoItems;
             Uuid = null;
+        }
+
+        /// <summary>
+        ///     Send a ConnectUpdate packet and set the tags and ItemsHandlingFlags for the current connection to the provided params.
+        /// </summary>
+        /// <param name="tags">New tags for the current connection.</param>
+        public void UpdateConnectionOptions(string[] tags)
+        {
+            UpdateConnectionOptions(tags, ItemsHandlingFlags);
+        }
+
+        /// <summary>
+        ///     Send a ConnectUpdate packet and set the tags and ItemsHandlingFlags for the current connection to the provided params.
+        /// </summary>
+        /// <param name="itemsHandlingFlags">New ItemsHandlingFlags for the current connection.</param>
+        public void UpdateConnectionOptions(ItemsHandlingFlags itemsHandlingFlags)
+        {
+            UpdateConnectionOptions(Tags, ItemsHandlingFlags);
+        }
+
+        /// <summary>
+        ///     Send a ConnectUpdate packet and set the tags and ItemsHandlingFlags for the current connection to the provided params.
+        /// </summary>
+        /// <param name="tags">New tags for the current connection.</param>
+        /// <param name="itemsHandlingFlags">New ItemsHandlingFlags for the current connection.</param>
+        public void UpdateConnectionOptions(string[] tags, ItemsHandlingFlags itemsHandlingFlags)
+        {
+            SetConnectionParameters(Game, tags, itemsHandlingFlags, Uuid);
+
+            socket.SendPacket(new ConnectUpdatePacket
+            {
+                Tags = Tags,
+                ItemsHandling = ItemsHandlingFlags
+            });
         }
     }
 }


### PR DESCRIPTION
Deathlink nolonger triggers of own send DeathLink's
Deathlink can now be toggled
Session.CreateDeathLinkServiceAndEnable change to Session.CreateDeathLinkService().EnableDeathLink()
Session.UpdateConnectionOptions moved to Session.ConnectionInfo.UpdateConnectionOptions
