### PR TITLE
Color polyfill (fixes #66)

### DIFF
--- a/Archipelago.MultiClient.Net.Tests/MessageLogHelperFixture.cs
+++ b/Archipelago.MultiClient.Net.Tests/MessageLogHelperFixture.cs
@@ -2,10 +2,10 @@
 using Archipelago.MultiClient.Net.Helpers;
 using Archipelago.MultiClient.Net.Models;
 using Archipelago.MultiClient.Net.Packets;
+using Archipelago.MultiClient.Net.Colors;
 using NSubstitute;
 using NUnit.Framework;
 using System.Collections.Generic;
-using System.Drawing;
 
 namespace Archipelago.MultiClient.Net.Tests
 {

--- a/Archipelago.MultiClient.Net/Colors/Color.cs
+++ b/Archipelago.MultiClient.Net/Colors/Color.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+
+namespace Archipelago.MultiClient.Net.Colors
+{
+    /// <summary>
+    /// Polyfill for System.Drawing.Color for games on runtimes which do not supply a `System.Drawing.dll`.
+    /// Not focused on memory or computation efficiency, we just need something that works reasonably well.
+    /// Transparency/alpha channel is not handled.
+    /// </summary>
+    public partial struct Color : IEquatable<Color>
+    {
+        public Color(byte r, byte g, byte b)
+        {
+            R = r;
+            G = g;
+            B = b;
+        }
+
+        public byte R { get; set; }
+
+        public byte G { get; set; }
+
+        public byte B { get; set; }
+
+        public override bool Equals(object obj)
+        {
+            return obj is Color color &&
+                   R == color.R &&
+                   G == color.G &&
+                   B == color.B;
+        }
+
+        public bool Equals(Color other)
+{
+            return R == other.R &&
+                   G == other.G &&
+                   B == other.B;
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = -1520100960;
+            hashCode = hashCode * -1521134295 + R.GetHashCode();
+            hashCode = hashCode * -1521134295 + G.GetHashCode();
+            hashCode = hashCode * -1521134295 + B.GetHashCode();
+            return hashCode;
+        }
+
+        public static bool operator ==(Color left, Color right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(Color left, Color right)
+        {
+            return !(left == right);
+        }
+
+        public static explicit operator ConsoleColor(Color color)
+        {
+            if (consoleColorConversions.TryGetValue(color, out var consoleColor))
+            {
+                return consoleColor;
+            }
+            else
+            {
+                throw new InvalidCastException($"Cannot cast Color(R={color.R},G={color.G},B={color.B}) to a ConsoleColor.");
+            }
+        }
+    }
+}

--- a/Archipelago.MultiClient.Net/Colors/Color.cs
+++ b/Archipelago.MultiClient.Net/Colors/Color.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Drawing;
-using System.Linq;
-using System.Text;
 
 namespace Archipelago.MultiClient.Net.Colors
 {

--- a/Archipelago.MultiClient.Net/Colors/Color.static.cs
+++ b/Archipelago.MultiClient.Net/Colors/Color.static.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Archipelago.MultiClient.Net.Colors
 {

--- a/Archipelago.MultiClient.Net/Colors/Color.static.cs
+++ b/Archipelago.MultiClient.Net/Colors/Color.static.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Archipelago.MultiClient.Net.Colors
+{
+    public partial struct Color
+    {
+        public static Color Red = new Color(255, 0, 0);
+
+        public static Color Green = new Color(0, 128, 0);
+
+        public static Color Yellow = new Color(255, 255, 0);
+
+        public static Color Blue = new Color(0, 0, 255);
+
+        public static Color Magenta = new Color(255, 0, 255);
+
+        public static Color Cyan = new Color(0, 255, 255);
+
+        public static Color Black = new Color(0, 0, 0);
+
+        public static Color White = new Color(255, 255, 255);
+
+        public static Color SlateBlue = new Color(106, 90, 205);
+
+        public static Color Salmon = new Color(250, 128, 114);
+
+        public static Color Plum = new Color(221, 160, 221);
+
+        private static Dictionary<Color, ConsoleColor> consoleColorConversions = new Dictionary<Color, ConsoleColor>()
+        {
+            [Red] = ConsoleColor.Red,
+            [Green] = ConsoleColor.Green,
+            [Yellow] = ConsoleColor.Yellow,
+            [Blue] = ConsoleColor.Blue,
+            [Magenta] = ConsoleColor.Magenta,
+            [Cyan] = ConsoleColor.Cyan,
+            [Black] = ConsoleColor.Black,
+            [White] = ConsoleColor.White,
+        };
+    }
+}

--- a/Archipelago.MultiClient.Net/Helpers/MessageLogHelper.cs
+++ b/Archipelago.MultiClient.Net/Helpers/MessageLogHelper.cs
@@ -1,8 +1,8 @@
 ﻿using Archipelago.MultiClient.Net.Enums;
 using Archipelago.MultiClient.Net.Models;
 using Archipelago.MultiClient.Net.Packets;
+using Archipelago.MultiClient.Net.Colors;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Linq;
 using System.Text;
 


### PR DESCRIPTION
Remove usage of `System.Drawing.Color` and use a new polyfill class `Archipelago.MultiClient.Net.Colors.Color`.