### PR TITLE
Increase concurrentcollections test coverage

### DIFF
--- a/Archipelago.MultiClient.Net.Tests/ConcurrentCollectionsFixture.cs
+++ b/Archipelago.MultiClient.Net.Tests/ConcurrentCollectionsFixture.cs
@@ -8,6 +8,25 @@ namespace Archipelago.MultiClient.Net.Tests
     public class ConcurrentCollectionsFixture
     {
         [Test]
+        public void ConcurrentQueue_EnqueueSingleItem_ItemIsEnqueued()
+        {
+            ConcurrentQueue<int> queue = new ConcurrentQueue<int>();
+            queue.Enqueue(1);
+
+            Assert.That(queue.Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void ConcurrentQueue_QueueHasItems_ClearQueue_QueueIsEmpty()
+        {
+            ConcurrentQueue<int> queue = new ConcurrentQueue<int>();
+            queue.Enqueue(1);
+            queue.Clear();
+
+            Assert.That(queue.IsEmpty, Is.True);
+        }
+
+        [Test]
         public void ConcurrentQueue_HasNoItems_GetIsEmpty_ReturnsTrue()
         {
             ConcurrentQueue<int> queue = new ConcurrentQueue<int>();
@@ -22,6 +41,98 @@ namespace Archipelago.MultiClient.Net.Tests
             queue.Enqueue(1);
 
             Assert.That(queue.IsEmpty, Is.False);
+        }
+
+        [Test]
+        public void ConcurrentQueue_HasNoItems_TryPeek_ReturnsFalse()
+        {
+            ConcurrentQueue<int> queue = new ConcurrentQueue<int>();
+
+            Assert.That(queue.TryPeek(out var item), Is.False);
+        }
+
+        [Test]
+        public void ConcurrentQueue_HasNoItems_TryPeek_AssignsDefaultValue()
+        {
+            ConcurrentQueue<int> queue = new ConcurrentQueue<int>();
+            queue.TryPeek(out var item);
+
+            Assert.That(item, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void ConcurrentQueue_HasItems_TryPeek_ReturnsTrue()
+        {
+            ConcurrentQueue<int> queue = new ConcurrentQueue<int>();
+            queue.Enqueue(1);
+
+            Assert.That(queue.TryPeek(out var item), Is.True);
+        }
+
+        [Test]
+        public void ConcurrentQueue_HasItems_TryPeek_AssignsCorrectValue()
+        {
+            ConcurrentQueue<int> queue = new ConcurrentQueue<int>();
+            queue.Enqueue(1);
+            queue.TryPeek(out var item);
+
+            Assert.That(item, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void ConcurrentQueue_HasItems_TryPeek_DoesNotDequeueItem()
+        {
+            ConcurrentQueue<int> queue = new ConcurrentQueue<int>();
+            queue.Enqueue(1);
+            queue.TryPeek(out var item);
+
+            Assert.That(queue.Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void ConcurrentQueue_HasNoItems_TryDequeue_ReturnsFalse()
+        {
+            ConcurrentQueue<int> queue = new ConcurrentQueue<int>();
+
+            Assert.That(queue.TryDequeue(out var item), Is.False);
+        }
+
+        [Test]
+        public void ConcurrentQueue_HasNoItems_TryDequeue_AssignsDefaultValue()
+        {
+            ConcurrentQueue<int> queue = new ConcurrentQueue<int>();
+            queue.TryDequeue(out var item);
+
+            Assert.That(item, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void ConcurrentQueue_HasItems_TryDequeue_ReturnsTrue()
+        {
+            ConcurrentQueue<int> queue = new ConcurrentQueue<int>();
+            queue.Enqueue(1);
+
+            Assert.That(queue.TryDequeue(out var item), Is.True);
+        }
+
+        [Test]
+        public void ConcurrentQueue_HasItems_TryDequeue_AssignsCorrectValue()
+        {
+            ConcurrentQueue<int> queue = new ConcurrentQueue<int>();
+            queue.Enqueue(1);
+            queue.TryDequeue(out var item);
+
+            Assert.That(item, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void ConcurrentQueue_HasItems_TryDequeue_DoesDequeueItem()
+        {
+            ConcurrentQueue<int> queue = new ConcurrentQueue<int>();
+            queue.Enqueue(1);
+            queue.TryDequeue(out var item);
+
+            Assert.That(queue.Count, Is.EqualTo(0));
         }
     }
 }

--- a/Archipelago.MultiClient.Net.Tests/ConcurrentHashSetFixture.cs
+++ b/Archipelago.MultiClient.Net.Tests/ConcurrentHashSetFixture.cs
@@ -1,0 +1,85 @@
+﻿using Archipelago.MultiClient.Net.ConcurrentCollection;
+using NUnit.Framework;
+using System.Linq;
+
+namespace Archipelago.MultiClient.Net.Tests
+{
+    [TestFixture]
+    public class ConcurrentHashSetFixture
+    {
+        [Test]
+        public void ConcurrentHashSet_TryAdd_ItemIsntAlreadyPresent_ReturnsTrue()
+        {
+            var hashset = new ConcurrentHashSet<int>();
+            
+            Assert.That(hashset.TryAdd(1), Is.True);
+        }
+
+        [Test]
+        public void ConcurrentHashSet_TryAdd_ItemIsAlreadyPresent_ReturnsFalse()
+        {
+            var hashset = new ConcurrentHashSet<int>();
+            hashset.TryAdd(1);
+
+            Assert.That(hashset.TryAdd(1), Is.False);
+        }
+
+        [Test]
+        public void ConcurrentHashSet_Contains_ItemIsntAlreadyPresent_ReturnsFalse()
+        {
+            var hashset = new ConcurrentHashSet<int>();
+
+            Assert.That(hashset.Contains(1), Is.False);
+        }
+
+        [Test]
+        public void ConcurrentHashSet_Contains_ItemIsAlreadyPresent_ReturnsTrue()
+        {
+            var hashset = new ConcurrentHashSet<int>();
+            hashset.TryAdd(1);
+
+            Assert.That(hashset.Contains(1), Is.True);
+        }
+
+        [Test]
+        public void ConcurrentHashSet_ToArray_ReturnsCorrectArrayContents()
+        {
+            var hashset = new ConcurrentHashSet<int>();
+            hashset.TryAdd(1);
+            hashset.TryAdd(2);
+
+            Assert.That(hashset.ToArray(), Is.EquivalentTo(Enumerable.Range(1, 2)));
+        }
+
+        [Test]
+        public void ConcurrentHashSet_UnionWith_OtherSet_ProducesCorrectUnion()
+        {
+            var hashset = new ConcurrentHashSet<int>();
+            hashset.TryAdd(1);
+            hashset.UnionWith(new int[] { 1, 2, 3 });
+
+            Assert.That(hashset.ToArray(), Is.EquivalentTo(Enumerable.Range(1,3)));
+        }
+
+        [Test]
+        public void ConcurrentHashSet_AsToReadOnlyCollection_ProducesCorrectContents()
+        {
+            var hashset = new ConcurrentHashSet<int>();
+            hashset.UnionWith(new int[] { 1, 2, 3 });
+
+            Assert.That(hashset.AsToReadOnlyCollection(), Is.EquivalentTo(Enumerable.Range(1, 3)));
+        }
+
+        [Test]
+        public void ConcurrentHashSet_AsToReadOnlyCollectionExcept_ProducesCorrectContents()
+        {
+            var hashset = new ConcurrentHashSet<int>();
+            hashset.UnionWith(new int[] { 1, 2, 3 });
+
+            var other = new ConcurrentHashSet<int>();
+            other.TryAdd(3);
+
+            Assert.That(hashset.AsToReadOnlyCollectionExcept(other), Is.EquivalentTo(Enumerable.Range(1, 2)));
+        }
+    }
+}

--- a/Archipelago.MultiClient.Net.Tests/ConcurrentListFixture.cs
+++ b/Archipelago.MultiClient.Net.Tests/ConcurrentListFixture.cs
@@ -1,0 +1,54 @@
+﻿using Archipelago.MultiClient.Net.ConcurrentCollection;
+using NUnit.Framework;
+using System.Linq;
+
+namespace Archipelago.MultiClient.Net.Tests
+{
+    [TestFixture]
+    public class ConcurrentListFixture
+    {
+        [Test]
+        public void ConcurrentList_AddItem_CorrectlyAddsItem()
+        {
+            var list = new ConcurrentList<int>();
+            list.Add(1);
+
+            Assert.That(list.Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void ConcurrentList_Count_ReturnsCorrectCount()
+        {
+            var list = new ConcurrentList<int>();
+            list.Add(1);
+            list.Add(1);
+            list.Add(1);
+            list.Add(1);
+            list.Add(1);
+
+            Assert.That(list.Count, Is.EqualTo(5));
+        }
+
+        [Test]
+        public void ConcurrentList_AsReadOnlyCollection_ReturnsCorrectContents()
+        {
+            var list = new ConcurrentList<int>();
+            list.Add(1);
+
+            Assert.That(list.AsReadOnlyCollection(), Is.EquivalentTo(Enumerable.Range(1,1)));
+        }
+
+        [Test]
+        public void ConcurrentList_Clear_RemovesAllContents()
+        {
+            var list = new ConcurrentList<int>();
+            list.Add(1);
+            list.Add(1);
+            list.Add(1);
+            list.Add(1);
+            list.Clear();
+
+            Assert.That(list.Count, Is.Zero);
+        }
+    }
+}

--- a/Archipelago.MultiClient.Net.Tests/ConcurrentQueueFixture.cs
+++ b/Archipelago.MultiClient.Net.Tests/ConcurrentQueueFixture.cs
@@ -5,7 +5,7 @@ using NUnit.Framework;
 namespace Archipelago.MultiClient.Net.Tests
 {
     [TestFixture]
-    public class ConcurrentCollectionsFixture
+    public class ConcurrentQueueFixture
     {
         [Test]
         public void ConcurrentQueue_EnqueueSingleItem_ItemIsEnqueued()

--- a/Archipelago.MultiClient.Net/ConcurrentCollection/ConcurrentQueue.cs
+++ b/Archipelago.MultiClient.Net/ConcurrentCollection/ConcurrentQueue.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Archipelago.MultiClient.Net.ConcurrentCollection
 {
-    class ConcurrentQueue<T>
+    internal class ConcurrentQueue<T>
     {
         public int Count => queue.Count;
 

--- a/Archipelago.MultiClient.Net/ConcurrentCollection/ConcurrentQueue.cs
+++ b/Archipelago.MultiClient.Net/ConcurrentCollection/ConcurrentQueue.cs
@@ -5,6 +5,8 @@ namespace Archipelago.MultiClient.Net.ConcurrentCollection
 {
     class ConcurrentQueue<T>
     {
+        public int Count => queue.Count;
+
         private readonly Queue<T> queue = new Queue<T>();
 
         private readonly object lockObject = new object();
@@ -24,6 +26,12 @@ namespace Archipelago.MultiClient.Net.ConcurrentCollection
         {
             lock (lockObject)
             {
+                if (IsEmpty)
+                {
+                    item = default;
+                    return false;
+                }
+
                 item = queue.Peek();
                 return true;
             }
@@ -33,6 +41,12 @@ namespace Archipelago.MultiClient.Net.ConcurrentCollection
         {
             lock (lockObject)
             {
+                if (IsEmpty)
+                {
+                    item = default;
+                    return false;
+                }
+
                 item = queue.Dequeue();
                 return true;
             }


### PR DESCRIPTION
Attempt to add more tests around concurrent collections so we have reasonable/expected behaviors and so we don't deviate from those behaviors.