### PR TITLE
Add parenthesis so code doesn't crash

### DIFF
--- a/Archipelago.MultiClient.Net/Helpers/ArchipelagoSocketHelper_websocket-sharp.cs
+++ b/Archipelago.MultiClient.Net/Helpers/ArchipelagoSocketHelper_websocket-sharp.cs
@@ -43,7 +43,7 @@ namespace Archipelago.MultiClient.Net.Helpers
         ///     Does not emit a ping to determine if the connection is stable.
         /// </summary>
         public bool Connected => webSocket != null &&
-	        webSocket.ReadyState == WebSocketState.Open || webSocket.ReadyState == WebSocketState.Closing;
+	        (webSocket.ReadyState == WebSocketState.Open || webSocket.ReadyState == WebSocketState.Closing);
 
         internal WebSocket webSocket;
 


### PR DESCRIPTION
The current code compiles down to this:
```
public bool Connected
{
	get
	{
		return (this.webSocket != null && this.webSocket.ReadyState == WebSocketState.Open) || this.webSocket.ReadyState == WebSocketState.Closing;
	}
}
```
But this allows `webSocket` to be null in the last check. This change makes it so we never dereference `webSocket` if it's null.