### PR TITLE
Remove superflous line in LoginAsync

### DIFF
--- a/Archipelago.MultiClient.Net/ArchipelagoSession.cs
+++ b/Archipelago.MultiClient.Net/ArchipelagoSession.cs
@@ -279,7 +279,6 @@ namespace Archipelago.MultiClient.Net
 
 			if (!roomInfoPacketTask.Task.IsCompleted)
             {
-                loginResultTask = new TaskCompletionSource<LoginResult>();
                 loginResultTask.TrySetResult(new LoginFailure("You are not connected, run ConnectAsync() first"));
                 return loginResultTask.Task;
             }


### PR DESCRIPTION
removes a loginResultTask = new TaskCompletionSource<LoginResult>();