### PR TITLE
fix retrieve typo in ArchipelagoPacketBase.cs

### DIFF
--- a/Archipelago.MultiClient.Net/ArchipelagoPacketBase.cs
+++ b/Archipelago.MultiClient.Net/ArchipelagoPacketBase.cs
@@ -17,7 +17,7 @@ namespace Archipelago.MultiClient.Net
         public abstract ArchipelagoPacketType PacketType { get; }
 
         /// <summary>
-        /// Retreive the basic jobject that was send by the server.
+        /// Retrieve the basic jobject that was send by the server.
         /// Its not recommended to use this however the JObject allows accessing properties are not available in the library
         /// </summary>
         /// <returns></returns>


### PR DESCRIPTION
Changed the  single line in the web editor, no idea why the whole thing is a diff.