### PR TITLE
Fix IsRelatedToActivePlayer logic for itemlink groups

### DIFF
--- a/Archipelago.MultiClient.Net.Tests/Archipelago.MultiClient.Net.Tests.csproj
+++ b/Archipelago.MultiClient.Net.Tests/Archipelago.MultiClient.Net.Tests.csproj
@@ -2,6 +2,7 @@
 	<PropertyGroup>
 		<TargetFrameworks>net47;net471;net472;net48</TargetFrameworks>
 		<IsPackable>false</IsPackable>
+		<LangVersion>latest</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Archipelago.MultiClient.Net.Tests/MessageLogHelperFixture.cs
+++ b/Archipelago.MultiClient.Net.Tests/MessageLogHelperFixture.cs
@@ -304,6 +304,7 @@ namespace Archipelago.MultiClient.Net.Tests
 		{
 			var socket = Substitute.For<IArchipelagoSocketHelper>();
 			var itemInfoResolver = Substitute.For<IItemInfoResolver>();
+			var connectionInfo = Substitute.For<IConnectionInfoProvider>();
 			itemInfoResolver.GetItemName(Arg.Any<long>(), Arg.Any<string>()).Returns(_ => null);
 			itemInfoResolver.GetLocationName(1000L, "Game3").Returns("ItemAtLocation1000InGame3");
 			var players = Substitute.For<IPlayerHelper>();
@@ -316,9 +317,7 @@ namespace Archipelago.MultiClient.Net.Tests
 				new PlayerInfo { Team = 0, Slot = 5, Game = "Game5" }
 			}));
 			players.GetPlayerInfo(Arg.Any<int>(), Arg.Any<int>()).Returns(x => players.Players[x.ArgAt<int>(0)][x.ArgAt<int>(1)]);
-			var connectionInfo = Substitute.For<IConnectionInfoProvider>();
-			connectionInfo.Team.Returns(0);
-			connectionInfo.Slot.Returns(5);
+			players.ActivePlayer.Returns(new PlayerInfo { Team = 0, Slot = 5 });
 
 			var sut = new MessageLogHelper(socket, itemInfoResolver, players, connectionInfo);
 
@@ -352,10 +351,10 @@ namespace Archipelago.MultiClient.Net.Tests
 			Assert.That(logMessage.Receiver.Slot, Is.EqualTo(5));
 			Assert.That(logMessage.Sender.Slot, Is.EqualTo(3));
 
-			Assert.That(logMessage.IsReceiverTheActivePlayer, Is.EqualTo(true));
-			Assert.That(logMessage.IsSenderTheActivePlayer, Is.EqualTo(false));
+			Assert.That(logMessage.IsReceiverTheActivePlayer, Is.True);
+			Assert.That(logMessage.IsSenderTheActivePlayer, Is.False);
 
-			Assert.That(logMessage.IsRelatedToActivePlayer, Is.EqualTo(true));
+			Assert.That(logMessage.IsRelatedToActivePlayer, Is.True);
 		}
 
 		[Test]
@@ -422,6 +421,7 @@ namespace Archipelago.MultiClient.Net.Tests
 		{
 			var socket = Substitute.For<IArchipelagoSocketHelper>();
 			var itemInfoResolver = Substitute.For<IItemInfoResolver>();
+			var connectionInfo = Substitute.For<IConnectionInfoProvider>();
 			itemInfoResolver.GetItemName(100L, "Game2").Returns("Item100FromGame3");
 			itemInfoResolver.GetLocationName(Arg.Any<long>(), Arg.Any<string>()).Returns(_ => null);
 			var players = Substitute.For<IPlayerHelper>();
@@ -434,9 +434,7 @@ namespace Archipelago.MultiClient.Net.Tests
 				new PlayerInfo { Team = 0, Slot = 5, Game = "Game5" }
 			}));
 			players.GetPlayerInfo(Arg.Any<int>(), Arg.Any<int>()).Returns(x => players.Players[x.ArgAt<int>(0)][x.ArgAt<int>(1)]);
-			var connectionInfo = Substitute.For<IConnectionInfoProvider>();
-			connectionInfo.Team.Returns(0);
-			connectionInfo.Slot.Returns(5);
+			players.ActivePlayer.Returns(new PlayerInfo { Team = 0, Slot = 5 });
 
 			var sut = new MessageLogHelper(socket, itemInfoResolver, players, connectionInfo);
 
@@ -471,12 +469,12 @@ namespace Archipelago.MultiClient.Net.Tests
 			Assert.That(logMessage.Receiver.Slot, Is.EqualTo(2));
 			Assert.That(logMessage.Sender.Slot, Is.EqualTo(3));
 
-			Assert.That(logMessage.IsReceiverTheActivePlayer, Is.EqualTo(false));
-			Assert.That(logMessage.IsSenderTheActivePlayer, Is.EqualTo(false));
+			Assert.That(logMessage.IsReceiverTheActivePlayer, Is.False);
+			Assert.That(logMessage.IsSenderTheActivePlayer, Is.False);
 
-			Assert.That(logMessage.IsRelatedToActivePlayer, Is.EqualTo(false));
+			Assert.That(logMessage.IsRelatedToActivePlayer, Is.False);
 
-			Assert.That(logMessage.IsFound, Is.EqualTo(true));
+			Assert.That(logMessage.IsFound, Is.True);
 		}
 
 		[Test]
@@ -484,18 +482,11 @@ namespace Archipelago.MultiClient.Net.Tests
 		{
 			var socket = Substitute.For<IArchipelagoSocketHelper>();
 			var itemInfoResolver = Substitute.For<IItemInfoResolver>();
+			var connectionInfo = Substitute.For<IConnectionInfoProvider>();
 			var players = Substitute.For<IPlayerHelper>();
 			players.GetPlayerAlias(5).Returns("LocalPlayer");
-			players.Players.Returns(GetPlayerCollection(new List<PlayerInfo> {
-				new PlayerInfo { Team = 0, Slot = 1 },
-				new PlayerInfo { Team = 0, Slot = 2 },
-				new PlayerInfo { Team = 0, Slot = 3 },
-				new PlayerInfo { Team = 0, Slot = 4 },
-				new PlayerInfo { Team = 0, Slot = 5 }
-			}));
-			var connectionInfo = Substitute.For<IConnectionInfoProvider>();
-			connectionInfo.Team.Returns(0);
-			connectionInfo.Slot.Returns(5);
+			players.GetPlayerInfo(0, 3).Returns(new PlayerInfo { Team = 0, Slot = 3 });
+			players.ActivePlayer.Returns(new PlayerInfo { Team = 0, Slot = 5 });
 
 			var sut = new MessageLogHelper(socket, itemInfoResolver, players, connectionInfo);
 
@@ -521,9 +512,9 @@ namespace Archipelago.MultiClient.Net.Tests
 
 			Assert.That(logMessage.Tags, Is.EquivalentTo(new[] { "TAG" }));
 
-			Assert.That(logMessage.IsActivePlayer, Is.EqualTo(false));
+			Assert.That(logMessage.IsActivePlayer, Is.False);
 
-			Assert.That(logMessage.IsRelatedToActivePlayer, Is.EqualTo(false));
+			Assert.That(logMessage.IsRelatedToActivePlayer, Is.False);
 		}
 
 		[Test]
@@ -531,18 +522,11 @@ namespace Archipelago.MultiClient.Net.Tests
 		{
 			var socket = Substitute.For<IArchipelagoSocketHelper>();
 			var itemInfoResolver = Substitute.For<IItemInfoResolver>();
+			var connectionInfo = Substitute.For<IConnectionInfoProvider>();
 			var players = Substitute.For<IPlayerHelper>();
 			players.GetPlayerAlias(5).Returns("LocalPlayer");
-			players.Players.Returns(GetPlayerCollection(new List<PlayerInfo> {
-				new PlayerInfo { Team = 0, Slot = 1 },
-				new PlayerInfo { Team = 0, Slot = 2 },
-				new PlayerInfo { Team = 0, Slot = 3 },
-				new PlayerInfo { Team = 0, Slot = 4 },
-				new PlayerInfo { Team = 0, Slot = 5 }
-			}));
-			var connectionInfo = Substitute.For<IConnectionInfoProvider>();
-			connectionInfo.Team.Returns(0);
-			connectionInfo.Slot.Returns(5);
+			players.GetPlayerInfo(0, 5).Returns(new PlayerInfo { Team = 0, Slot = 5 });
+			players.ActivePlayer.Returns(new PlayerInfo { Team = 0, Slot = 5 });
 
 			var sut = new MessageLogHelper(socket, itemInfoResolver, players, connectionInfo);
 
@@ -565,9 +549,9 @@ namespace Archipelago.MultiClient.Net.Tests
 			Assert.That(logMessage.Player.Team, Is.EqualTo(0));
 			Assert.That(logMessage.Player.Slot, Is.EqualTo(5));
 
-			Assert.That(logMessage.IsActivePlayer, Is.EqualTo(true));
+			Assert.That(logMessage.IsActivePlayer, Is.True);
 
-			Assert.That(logMessage.IsRelatedToActivePlayer, Is.EqualTo(true));
+			Assert.That(logMessage.IsRelatedToActivePlayer, Is.True);
 		}
 
 		[Test]
@@ -575,18 +559,19 @@ namespace Archipelago.MultiClient.Net.Tests
 		{
 			var socket = Substitute.For<IArchipelagoSocketHelper>();
 			var itemInfoResolver = Substitute.For<IItemInfoResolver>();
+			var connectionInfo = Substitute.For<IConnectionInfoProvider>();
 			var players = Substitute.For<IPlayerHelper>();
 			players.GetPlayerAlias(5).Returns("LocalPlayer");
-			players.Players.Returns(GetPlayerCollection(new List<PlayerInfo> {
-				new PlayerInfo { Team = 0, Slot = 1, Groups = new []{ new NetworkSlot { GroupMembers = new []{ 2,3,5 } } } },
-				new PlayerInfo { Team = 0, Slot = 2, Groups = new []{ new NetworkSlot { GroupMembers = new []{ 1,3,5 } } } },
-				new PlayerInfo { Team = 0, Slot = 3, Groups = new []{ new NetworkSlot { GroupMembers = new []{ 1,2,5 } } } },
-				new PlayerInfo { Team = 0, Slot = 4 },
-				new PlayerInfo { Team = 0, Slot = 5, Groups = new []{ new NetworkSlot { GroupMembers = new []{ 1,2,3 } } } }
-			}));
-			var connectionInfo = Substitute.For<IConnectionInfoProvider>();
-			connectionInfo.Team.Returns(0);
-			connectionInfo.Slot.Returns(5);
+			players.GetPlayerInfo(0, 2).Returns(new PlayerInfo 
+			{ 
+				Team = 0, Slot = 2, 
+				Groups = [new NetworkSlot { GroupMembers = [1, 3, 5] }] 
+			});
+			players.ActivePlayer.Returns(new PlayerInfo 
+			{ 
+				Team = 0, Slot = 5, 
+				Groups = [new NetworkSlot { GroupMembers = [1, 2, 3] }] 
+			});
 
 			var sut = new MessageLogHelper(socket, itemInfoResolver, players, connectionInfo);
 
@@ -596,7 +581,7 @@ namespace Archipelago.MultiClient.Net.Tests
 
 			var packet = new ChatPrintJsonPacket
 			{
-				Data = new[] { new JsonMessagePart { Text = "" } },
+				Data = [new JsonMessagePart { Text = "" }],
 				Team = 0,
 				Slot = 2,
 				Message = "Silly duplicated data",
@@ -610,9 +595,9 @@ namespace Archipelago.MultiClient.Net.Tests
 			Assert.That(logMessage.Player.Team, Is.EqualTo(0));
 			Assert.That(logMessage.Player.Slot, Is.EqualTo(2));
 
-			Assert.That(logMessage.IsActivePlayer, Is.EqualTo(false));
+			Assert.That(logMessage.IsActivePlayer, Is.False);
 
-			Assert.That(logMessage.IsRelatedToActivePlayer, Is.EqualTo(true));
+			Assert.That(logMessage.IsRelatedToActivePlayer, Is.False);
 
 			Assert.That(logMessage.Message, Is.EqualTo("Silly duplicated data"));
 		}
@@ -695,18 +680,11 @@ namespace Archipelago.MultiClient.Net.Tests
 		{
 			var socket = Substitute.For<IArchipelagoSocketHelper>();
 			var itemInfoResolver = Substitute.For<IItemInfoResolver>();
+			var connectionInfo = Substitute.For<IConnectionInfoProvider>();
 			var players = Substitute.For<IPlayerHelper>();
 			players.GetPlayerAlias(5).Returns("LocalPlayer");
-			players.Players.Returns(GetPlayerCollection(new List<PlayerInfo> {
-				new PlayerInfo { Team = 0, Slot = 1 },
-				new PlayerInfo { Team = 0, Slot = 2 },
-				new PlayerInfo { Team = 0, Slot = 3 },
-				new PlayerInfo { Team = 0, Slot = 4 },
-				new PlayerInfo { Team = 0, Slot = 5 }
-			}));
-			var connectionInfo = Substitute.For<IConnectionInfoProvider>();
-			connectionInfo.Team.Returns(0);
-			connectionInfo.Slot.Returns(5);
+			players.GetPlayerInfo(0, 3).Returns(new PlayerInfo { Team = 0, Slot = 3 });
+			players.ActivePlayer.Returns(new PlayerInfo { Team = 0, Slot = 5 });
 
 			var sut = new MessageLogHelper(socket, itemInfoResolver, players, connectionInfo);
 
@@ -732,9 +710,9 @@ namespace Archipelago.MultiClient.Net.Tests
 
 			Assert.That(logMessage.Tags, Is.EquivalentTo(new[] { "TAG", "TAG2" }));
 
-			Assert.That(logMessage.IsActivePlayer, Is.EqualTo(false));
+			Assert.That(logMessage.IsActivePlayer, Is.False);
 
-			Assert.That(logMessage.IsRelatedToActivePlayer, Is.EqualTo(false));
+			Assert.That(logMessage.IsRelatedToActivePlayer, Is.False);
 		}
 
 		[Test]
@@ -812,18 +790,11 @@ namespace Archipelago.MultiClient.Net.Tests
 		{
 			var socket = Substitute.For<IArchipelagoSocketHelper>();
 			var itemInfoResolver = Substitute.For<IItemInfoResolver>();
+			var connectionInfo = Substitute.For<IConnectionInfoProvider>();
 			var players = Substitute.For<IPlayerHelper>();
 			players.GetPlayerAlias(5).Returns("LocalPlayer");
-			players.Players.Returns(GetPlayerCollection(new List<PlayerInfo> {
-				new PlayerInfo { Team = 0, Slot = 1 },
-				new PlayerInfo { Team = 0, Slot = 2 },
-				new PlayerInfo { Team = 0, Slot = 3 },
-				new PlayerInfo { Team = 0, Slot = 4 },
-				new PlayerInfo { Team = 0, Slot = 5 }
-			}));
-			var connectionInfo = Substitute.For<IConnectionInfoProvider>();
-			connectionInfo.Team.Returns(0);
-			connectionInfo.Slot.Returns(5);
+			players.GetPlayerInfo(0, 3).Returns(new PlayerInfo { Team = 0, Slot = 3 });
+			players.ActivePlayer.Returns(new PlayerInfo { Team = 0, Slot = 5 });
 
 			var sut = new MessageLogHelper(socket, itemInfoResolver, players, connectionInfo);
 
@@ -856,18 +827,11 @@ namespace Archipelago.MultiClient.Net.Tests
 		{
 			var socket = Substitute.For<IArchipelagoSocketHelper>();
 			var itemInfoResolver = Substitute.For<IItemInfoResolver>();
+			var connectionInfo = Substitute.For<IConnectionInfoProvider>();
 			var players = Substitute.For<IPlayerHelper>();
 			players.GetPlayerAlias(5).Returns("LocalPlayer");
-			players.Players.Returns(GetPlayerCollection(new List<PlayerInfo> {
-				new PlayerInfo { Team = 0, Slot = 1 },
-				new PlayerInfo { Team = 0, Slot = 2 },
-				new PlayerInfo { Team = 0, Slot = 3 },
-				new PlayerInfo { Team = 0, Slot = 4 },
-				new PlayerInfo { Team = 0, Slot = 5 }
-			}));
-			var connectionInfo = Substitute.For<IConnectionInfoProvider>();
-			connectionInfo.Team.Returns(0);
-			connectionInfo.Slot.Returns(5);
+			players.GetPlayerInfo(0, 3).Returns(new PlayerInfo { Team = 0, Slot = 3 });
+			players.ActivePlayer.Returns(new PlayerInfo { Team = 0, Slot = 5 });
 
 			var sut = new MessageLogHelper(socket, itemInfoResolver, players, connectionInfo);
 
@@ -890,9 +854,9 @@ namespace Archipelago.MultiClient.Net.Tests
 			Assert.That(logMessage.Player.Team, Is.EqualTo(0));
 			Assert.That(logMessage.Player.Slot, Is.EqualTo(3));
 
-			Assert.That(logMessage.IsActivePlayer, Is.EqualTo(false));
+			Assert.That(logMessage.IsActivePlayer, Is.False);
 
-			Assert.That(logMessage.IsRelatedToActivePlayer, Is.EqualTo(false));
+			Assert.That(logMessage.IsRelatedToActivePlayer, Is.False);
 		}
 
 		[Test]
@@ -900,18 +864,11 @@ namespace Archipelago.MultiClient.Net.Tests
 		{
 			var socket = Substitute.For<IArchipelagoSocketHelper>();
 			var itemInfoResolver = Substitute.For<IItemInfoResolver>();
+			var connectionInfo = Substitute.For<IConnectionInfoProvider>();
 			var players = Substitute.For<IPlayerHelper>();
 			players.GetPlayerAlias(5).Returns("LocalPlayer");
-			players.Players.Returns(GetPlayerCollection(new List<PlayerInfo> {
-				new PlayerInfo { Team = 0, Slot = 1 },
-				new PlayerInfo { Team = 0, Slot = 2 },
-				new PlayerInfo { Team = 0, Slot = 3 },
-				new PlayerInfo { Team = 0, Slot = 4 },
-				new PlayerInfo { Team = 0, Slot = 5 }
-			}));
-			var connectionInfo = Substitute.For<IConnectionInfoProvider>();
-			connectionInfo.Team.Returns(0);
-			connectionInfo.Slot.Returns(5);
+			players.GetPlayerInfo(0, 3).Returns(new PlayerInfo { Team = 0, Slot = 3 });
+			players.ActivePlayer.Returns(new PlayerInfo { Team = 0, Slot = 5 });
 
 			var sut = new MessageLogHelper(socket, itemInfoResolver, players, connectionInfo);
 
@@ -934,9 +891,9 @@ namespace Archipelago.MultiClient.Net.Tests
 			Assert.That(logMessage.Player.Team, Is.EqualTo(0));
 			Assert.That(logMessage.Player.Slot, Is.EqualTo(3));
 
-			Assert.That(logMessage.IsActivePlayer, Is.EqualTo(false));
+			Assert.That(logMessage.IsActivePlayer, Is.False);
 
-			Assert.That(logMessage.IsRelatedToActivePlayer, Is.EqualTo(false));
+			Assert.That(logMessage.IsRelatedToActivePlayer, Is.False);
 		}
 		
 		[Test]
@@ -967,11 +924,116 @@ namespace Archipelago.MultiClient.Net.Tests
 	        Assert.That(logMessage.RemainingSeconds, Is.EqualTo(8));
         }
 
+		[Test]
+		public void PlayerSpecificLogMessage_for_group_should_be_related_to_active_player()
+		{
+			var socket = Substitute.For<IArchipelagoSocketHelper>();
+			var itemInfoResolver = Substitute.For<IItemInfoResolver>();
+			var connectionInfo = Substitute.For<IConnectionInfoProvider>();
+			var players = Substitute.For<IPlayerHelper>();
+			players.ActivePlayer.Returns(new PlayerInfo { Team = 0, Slot = 5 });
+			players.GetPlayerInfo(Arg.Any<int>(), Arg.Any<int>()).Returns(x => new PlayerInfo { Team = x.ArgAt<int>(0), Slot = x.ArgAt<int>(1) });
+			players.GetPlayerInfo(0, 3).Returns(new PlayerInfo { Team = 0, Slot = 3, GroupMembers = [1, 5] });
+
+			var sut = new MessageLogHelper(socket, itemInfoResolver, players, connectionInfo);
+
+			CollectLogMessage logMessage = null;
+			sut.OnMessageReceived += message => logMessage = message as CollectLogMessage;
+
+			var packet = new CollectPrintJsonPacket
+			{
+				Data = [new JsonMessagePart { Text = "" }],
+				Team = 0,
+				Slot = 3,
+				MessageType = JsonMessageType.Collect
+			};
+
+			socket.PacketReceived += Raise.Event<ArchipelagoSocketHelperDelagates.PacketReceivedHandler>(packet);
+
+			Assert.That(logMessage, Is.Not.Null);
+			Assert.That(logMessage.IsActivePlayer, Is.False);
+			Assert.That(logMessage.IsRelatedToActivePlayer, Is.True);
+		}
+
+		[Test]
+		public void ItemSendLogMessage_for_group_sender_should_be_related_to_active_player()
+		{
+			var socket = Substitute.For<IArchipelagoSocketHelper>();
+			var itemInfoResolver = Substitute.For<IItemInfoResolver>();
+			var connectionInfo = Substitute.For<IConnectionInfoProvider>();
+			var players = Substitute.For<IPlayerHelper>();
+			players.ActivePlayer.Returns(new PlayerInfo { Team = 0, Slot = 5 });
+			players.GetPlayerInfo(Arg.Any<int>(), Arg.Any<int>()).Returns(x => new PlayerInfo { Team = x.ArgAt<int>(0), Slot = x.ArgAt<int>(1) });
+			players.GetPlayerInfo(0, 3).Returns(new PlayerInfo { Team = 0, Slot = 3, GroupMembers = [1, 5] });
+
+			var sut = new MessageLogHelper(socket, itemInfoResolver, players, connectionInfo);
+
+			ItemSendLogMessage logMessage = null;
+			sut.OnMessageReceived += message => logMessage = message as ItemSendLogMessage;
+
+			var packet = new ItemPrintJsonPacket
+			{
+				Data = [new JsonMessagePart { Text = "" }],
+				ReceivingPlayer = 1,
+				Item = new NetworkItem
+				{
+					Player = 3
+				},
+				MessageType = JsonMessageType.ItemSend
+			};
+
+			socket.PacketReceived += Raise.Event<ArchipelagoSocketHelperDelagates.PacketReceivedHandler>(packet);
+
+			Assert.That(logMessage, Is.Not.Null);
+			Assert.That(logMessage.Sender.Slot, Is.EqualTo(3));
+			Assert.That(logMessage.Receiver.Slot, Is.EqualTo(1));
+			Assert.That(logMessage.IsSenderTheActivePlayer, Is.False);
+			Assert.That(logMessage.IsReceiverTheActivePlayer, Is.False);
+			Assert.That(logMessage.IsRelatedToActivePlayer, Is.True);
+		}
+
+		[Test]
+		public void ItemSendLogMessage_for_group_receiver_should_be_related_to_active_player()
+		{
+			var socket = Substitute.For<IArchipelagoSocketHelper>();
+			var itemInfoResolver = Substitute.For<IItemInfoResolver>();
+			var connectionInfo = Substitute.For<IConnectionInfoProvider>();
+			var players = Substitute.For<IPlayerHelper>();
+			players.ActivePlayer.Returns(new PlayerInfo { Team = 0, Slot = 5 });
+			players.GetPlayerInfo(Arg.Any<int>(), Arg.Any<int>()).Returns(x => new PlayerInfo { Team = x.ArgAt<int>(0), Slot = x.ArgAt<int>(1) });
+			players.GetPlayerInfo(0, 3).Returns(new PlayerInfo { Team = 0, Slot = 3, GroupMembers = [1, 5] });
+
+			var sut = new MessageLogHelper(socket, itemInfoResolver, players, connectionInfo);
+
+			ItemSendLogMessage logMessage = null;
+			sut.OnMessageReceived += message => logMessage = message as ItemSendLogMessage;
+
+			var packet = new ItemPrintJsonPacket
+			{
+				Data = [new JsonMessagePart { Text = "" }],
+				ReceivingPlayer = 3,
+				Item = new NetworkItem
+				{
+					Player = 1
+				},
+				MessageType = JsonMessageType.ItemSend
+			};
+
+			socket.PacketReceived += Raise.Event<ArchipelagoSocketHelperDelagates.PacketReceivedHandler>(packet);
+
+			Assert.That(logMessage, Is.Not.Null);
+			Assert.That(logMessage.Sender.Slot, Is.EqualTo(1));
+			Assert.That(logMessage.Receiver.Slot, Is.EqualTo(3));
+			Assert.That(logMessage.IsSenderTheActivePlayer, Is.False);
+			Assert.That(logMessage.IsReceiverTheActivePlayer, Is.False);
+			Assert.That(logMessage.IsRelatedToActivePlayer, Is.True);
+		}
+
 #if NET471 || NET472
 	    static Dictionary<int, ReadOnlyCollection<PlayerInfo>> GetPlayerCollection(IList<PlayerInfo> playerInfos) => 
 		    new Dictionary<int, ReadOnlyCollection<PlayerInfo>>(
 #else
-	    static ReadOnlyDictionary<int, ReadOnlyCollection<PlayerInfo>> GetPlayerCollection(IList<PlayerInfo> playerInfos) =>
+		static ReadOnlyDictionary<int, ReadOnlyCollection<PlayerInfo>> GetPlayerCollection(IList<PlayerInfo> playerInfos) =>
 		    new ReadOnlyDictionary<int, ReadOnlyCollection<PlayerInfo>>(
 #endif
 				new Dictionary<int, ReadOnlyCollection<PlayerInfo>> { {

--- a/Archipelago.MultiClient.Net/Helpers/LocationCheckHelper.cs
+++ b/Archipelago.MultiClient.Net/Helpers/LocationCheckHelper.cs
@@ -325,7 +325,7 @@ namespace Archipelago.MultiClient.Net.Helpers
 			                    item => item.Location,
 			                    item => {
 				                    var otherPlayer = players.GetPlayerInfo(item.Player) ?? new PlayerInfo();
-									return new ScoutedItemInfo(item, otherPlayer.Game, connectionInfoProvider.Game, itemInfoResolver, otherPlayer);
+									return new ScoutedItemInfo(item, otherPlayer.Game, connectionInfoProvider.Game, itemInfoResolver, players, otherPlayer);
 			                    });
 
 		                    locationInfoPacketCallbackTask.TrySetResult(items);
@@ -435,7 +435,7 @@ namespace Archipelago.MultiClient.Net.Helpers
 		            item => item.Location,
 		            item => {
 			            var otherPlayer = players.GetPlayerInfo(item.Player) ?? new PlayerInfo();
-			            return new ScoutedItemInfo(item, otherPlayer.Game, connectionInfoProvider.Game, itemInfoResolver, otherPlayer);
+			            return new ScoutedItemInfo(item, otherPlayer.Game, connectionInfoProvider.Game, itemInfoResolver, players, otherPlayer);
 		            });
 	            callback?.Invoke(items);
 			};

--- a/Archipelago.MultiClient.Net/Helpers/MessageLogHelper.cs
+++ b/Archipelago.MultiClient.Net/Helpers/MessageLogHelper.cs
@@ -66,29 +66,29 @@ namespace Archipelago.MultiClient.Net.Helpers
                 switch (linePacket)
                 {
 	                case ItemPrintJsonPacket itemPrintJson:
-		                message = new ItemSendLogMessage(parts, players, connectionInfo,
+		                message = new ItemSendLogMessage(parts, players,
 							itemPrintJson.ReceivingPlayer, itemPrintJson.Item.Player, itemPrintJson.Item, itemInfoResolver);
 		                break;
 	                case ItemCheatPrintJsonPacket itemCheatPrintJson:
-		                message = new ItemCheatLogMessage(parts, players, connectionInfo,
+		                message = new ItemCheatLogMessage(parts, players,
 			                itemCheatPrintJson.Team, itemCheatPrintJson.ReceivingPlayer, 
 			                itemCheatPrintJson.Item, itemInfoResolver);
 		                break;
 					case HintPrintJsonPacket hintPrintJson:
-                        message = new HintItemSendLogMessage(parts, players, connectionInfo,
+                        message = new HintItemSendLogMessage(parts, players,
 							hintPrintJson.ReceivingPlayer, hintPrintJson.Item.Player,
                             hintPrintJson.Item, hintPrintJson.Found.HasValue && hintPrintJson.Found.Value, itemInfoResolver);
                         break;
 	                case JoinPrintJsonPacket joinPrintJson:
-		                message = new JoinLogMessage(parts, players, connectionInfo,
+		                message = new JoinLogMessage(parts, players,
 							joinPrintJson.Team, joinPrintJson.Slot, joinPrintJson.Tags);
 		                break;
 	                case LeavePrintJsonPacket leavePrintJson:
-		                message = new LeaveLogMessage(parts, players, connectionInfo,
+		                message = new LeaveLogMessage(parts, players,
 							leavePrintJson.Team, leavePrintJson.Slot);
 		                break;
 	                case ChatPrintJsonPacket chatPrintJson:
-		                message = new ChatLogMessage(parts, players, connectionInfo,
+		                message = new ChatLogMessage(parts, players,
 							chatPrintJson.Team, chatPrintJson.Slot, chatPrintJson.Message);
 		                break;
 	                case ServerChatPrintJsonPacket serverChatPrintJson:
@@ -98,7 +98,7 @@ namespace Archipelago.MultiClient.Net.Helpers
 		                message = new TutorialLogMessage(parts);
 		                break;
 	                case TagsChangedPrintJsonPacket tagsPrintJson:
-		                message = new TagsChangedLogMessage(parts, players, connectionInfo,
+		                message = new TagsChangedLogMessage(parts, players,
 			                tagsPrintJson.Team, tagsPrintJson.Slot, tagsPrintJson.Tags);
 						break;
 	                case CommandResultPrintJsonPacket _:
@@ -108,15 +108,15 @@ namespace Archipelago.MultiClient.Net.Helpers
 		                message = new AdminCommandResultLogMessage(parts);
 		                break;
 	                case GoalPrintJsonPacket goalPrintJsonPacket:
-		                message = new GoalLogMessage(parts, players, connectionInfo,
+		                message = new GoalLogMessage(parts, players,
 			                goalPrintJsonPacket.Team, goalPrintJsonPacket.Slot);
 		                break;
 	                case ReleasePrintJsonPacket releasePrintJsonPacket:
-		                message = new ReleaseLogMessage(parts, players, connectionInfo,
+		                message = new ReleaseLogMessage(parts, players,
 			                releasePrintJsonPacket.Team, releasePrintJsonPacket.Slot);
 		                break;
 	                case CollectPrintJsonPacket collectPrintJsonPacket:
-		                message = new CollectLogMessage(parts, players, connectionInfo,
+		                message = new CollectLogMessage(parts, players,
 			                collectPrintJsonPacket.Team, collectPrintJsonPacket.Slot);
 		                break;
 					case CountdownPrintJsonPacket countdownPrintJson:

--- a/Archipelago.MultiClient.Net/MessageLog/Messages/ChatLogMessage.cs
+++ b/Archipelago.MultiClient.Net/MessageLog/Messages/ChatLogMessage.cs
@@ -16,8 +16,8 @@ namespace Archipelago.MultiClient.Net.MessageLog.Messages
 		public string Message { get; }
 
 		internal ChatLogMessage(MessagePart[] parts,
-			IPlayerHelper players, IConnectionInfoProvider connectionInfo, int team, int slot, string message) 
-			: base(parts, players, connectionInfo, team, slot)
+			IPlayerHelper players, int team, int slot, string message) 
+			: base(parts, players, team, slot)
 		{
 			Message = message;
 		}

--- a/Archipelago.MultiClient.Net/MessageLog/Messages/CollectLogMessage.cs
+++ b/Archipelago.MultiClient.Net/MessageLog/Messages/CollectLogMessage.cs
@@ -11,8 +11,8 @@ namespace Archipelago.MultiClient.Net.MessageLog.Messages
 	public class CollectLogMessage : PlayerSpecificLogMessage
 	{
 		internal CollectLogMessage(MessagePart[] parts,
-			IPlayerHelper players, IConnectionInfoProvider connectionInfo, int team, int slot) 
-			: base(parts, players, connectionInfo, team, slot)
+			IPlayerHelper players, int team, int slot) 
+			: base(parts, players, team, slot)
 		{
 		}
 	}

--- a/Archipelago.MultiClient.Net/MessageLog/Messages/GoalLogMessage.cs
+++ b/Archipelago.MultiClient.Net/MessageLog/Messages/GoalLogMessage.cs
@@ -11,8 +11,8 @@ namespace Archipelago.MultiClient.Net.MessageLog.Messages
 	public class GoalLogMessage : PlayerSpecificLogMessage
 	{
 		internal GoalLogMessage(MessagePart[] parts,
-			IPlayerHelper players, IConnectionInfoProvider connectionInfo, int team, int slot)
-			: base(parts, players, connectionInfo, team, slot)
+			IPlayerHelper players, int team, int slot)
+			: base(parts, players, team, slot)
 		{
 		}
 	}

--- a/Archipelago.MultiClient.Net/MessageLog/Messages/HintItemSendLogMessage.cs
+++ b/Archipelago.MultiClient.Net/MessageLog/Messages/HintItemSendLogMessage.cs
@@ -18,10 +18,9 @@ namespace Archipelago.MultiClient.Net.MessageLog.Messages
 		/// </summary>
 		public bool IsFound { get; }
 
-		internal HintItemSendLogMessage(MessagePart[] parts, 
-			IPlayerHelper players, IConnectionInfoProvider connectionInfo, 
+		internal HintItemSendLogMessage(MessagePart[] parts, IPlayerHelper players, 
 			int receiver, int sender, NetworkItem item, bool found, IItemInfoResolver itemInfoResolver) 
-			: base(parts, players, connectionInfo, receiver, sender, item, itemInfoResolver)
+			: base(parts, players, receiver, sender, item, itemInfoResolver)
 		{
 			IsFound = found;
 		}

--- a/Archipelago.MultiClient.Net/MessageLog/Messages/ItemCheatLogMessage.cs
+++ b/Archipelago.MultiClient.Net/MessageLog/Messages/ItemCheatLogMessage.cs
@@ -13,9 +13,9 @@ namespace Archipelago.MultiClient.Net.MessageLog.Messages
 	public class ItemCheatLogMessage : ItemSendLogMessage
 	{
 		internal ItemCheatLogMessage(MessagePart[] parts, 
-			IPlayerHelper players, IConnectionInfoProvider connectionInfo, 
+			IPlayerHelper players, 
 			int team, int slot, NetworkItem item, IItemInfoResolver itemInfoResolver)
-			: base(parts, players, connectionInfo, slot, 0, item, team, itemInfoResolver)
+			: base(parts, players, slot, 0, item, team, itemInfoResolver)
 		{
 		}
 	}

--- a/Archipelago.MultiClient.Net/MessageLog/Messages/JoinLogMessage.cs
+++ b/Archipelago.MultiClient.Net/MessageLog/Messages/JoinLogMessage.cs
@@ -16,8 +16,8 @@ namespace Archipelago.MultiClient.Net.MessageLog.Messages
 		public string[] Tags { get; }
 
 		internal JoinLogMessage(MessagePart[] parts,
-			IPlayerHelper players, IConnectionInfoProvider connectionInfo, int team, int slot, string[] tags)
-			: base(parts, players, connectionInfo, team, slot)
+			IPlayerHelper players, int team, int slot, string[] tags)
+			: base(parts, players, team, slot)
 		{
 			Tags = tags;
 		}

--- a/Archipelago.MultiClient.Net/MessageLog/Messages/LeaveLogMessage.cs
+++ b/Archipelago.MultiClient.Net/MessageLog/Messages/LeaveLogMessage.cs
@@ -11,8 +11,8 @@ namespace Archipelago.MultiClient.Net.MessageLog.Messages
 	public class LeaveLogMessage : PlayerSpecificLogMessage
 	{
 		internal LeaveLogMessage(MessagePart[] parts,
-			IPlayerHelper players, IConnectionInfoProvider connectionInfo, int team, int slot)
-			: base(parts, players, connectionInfo, team, slot)
+			IPlayerHelper players, int team, int slot)
+			: base(parts, players, team, slot)
 		{
 		}
 	}

--- a/Archipelago.MultiClient.Net/MessageLog/Messages/PlayerSpecificLogMessage.cs
+++ b/Archipelago.MultiClient.Net/MessageLog/Messages/PlayerSpecificLogMessage.cs
@@ -1,5 +1,6 @@
 ﻿using Archipelago.MultiClient.Net.Helpers;
 using Archipelago.MultiClient.Net.MessageLog.Parts;
+using System.Linq;
 
 namespace Archipelago.MultiClient.Net.MessageLog.Messages
 {
@@ -27,18 +28,13 @@ namespace Archipelago.MultiClient.Net.MessageLog.Messages
 		public bool IsRelatedToActivePlayer { get; }
 
 		internal PlayerSpecificLogMessage(MessagePart[] parts, 
-			IPlayerHelper players, IConnectionInfoProvider connectionInfo, int team, int slot)
+			IPlayerHelper players, int team, int slot)
 			: base(parts)
 		{
-			var playerList = players.Players;
-
-			IsActivePlayer = connectionInfo.Team == team && connectionInfo.Slot == slot;
-
-			Player = playerList.Count > team && playerList[team].Count > slot
-				? playerList[team][slot]
-				: new PlayerInfo();
-
-			IsRelatedToActivePlayer = IsActivePlayer || Player.IsSharingGroupWith(connectionInfo.Team, connectionInfo.Slot);
+			Player = players.GetPlayerInfo(team, slot) ?? new PlayerInfo();
+			IsActivePlayer = Player == players.ActivePlayer;
+			IsRelatedToActivePlayer = IsActivePlayer
+				|| (Player?.GetGroupMembers(players)?.Contains(players.ActivePlayer) ?? false);
 		}
 	}
 }

--- a/Archipelago.MultiClient.Net/MessageLog/Messages/ReleaseLogMessage.cs
+++ b/Archipelago.MultiClient.Net/MessageLog/Messages/ReleaseLogMessage.cs
@@ -11,8 +11,8 @@ namespace Archipelago.MultiClient.Net.MessageLog.Messages
 	public class ReleaseLogMessage : PlayerSpecificLogMessage
 	{
 		internal ReleaseLogMessage(MessagePart[] parts,
-			IPlayerHelper players, IConnectionInfoProvider connectionInfo, int team, int slot)
-			: base(parts, players, connectionInfo, team, slot)
+			IPlayerHelper players, int team, int slot)
+			: base(parts, players, team, slot)
 		{
 		}
 	}

--- a/Archipelago.MultiClient.Net/MessageLog/Messages/TagsChangedLogMessage.cs
+++ b/Archipelago.MultiClient.Net/MessageLog/Messages/TagsChangedLogMessage.cs
@@ -16,8 +16,8 @@ namespace Archipelago.MultiClient.Net.MessageLog.Messages
 		public string[] Tags { get; }
 
 		internal TagsChangedLogMessage(MessagePart[] parts,
-			IPlayerHelper players, IConnectionInfoProvider connectionInfo, int team, int slot, string[] tags)
-			: base(parts, players, connectionInfo, team, slot)
+			IPlayerHelper players, int team, int slot, string[] tags)
+			: base(parts, players, team, slot)
 		{
 			Tags = tags;
 		}

--- a/Archipelago.MultiClient.Net/Models/ItemInfo.cs
+++ b/Archipelago.MultiClient.Net/Models/ItemInfo.cs
@@ -1,6 +1,7 @@
 ﻿using Archipelago.MultiClient.Net.DataPackage;
 using Archipelago.MultiClient.Net.Enums;
 using Archipelago.MultiClient.Net.Helpers;
+using System.Linq;
 
 namespace Archipelago.MultiClient.Net.Models
 {
@@ -107,11 +108,20 @@ namespace Archipelago.MultiClient.Net.Models
 		public new PlayerInfo Player => base.Player;
 
 		/// <summary>
+		/// True if the player this message is concerning any slot groups (e.g. itemlinks) with the current connected player
+		/// </summary>
+		public bool IsRelatedToActivePlayer { get; }
+
+		/// <summary>
 		/// The constructor what else did you expect it to be
 		/// </summary>
-		public ScoutedItemInfo(NetworkItem item, string receiverGame, string senderGame, IItemInfoResolver itemInfoResolver, PlayerInfo player) 
+		public ScoutedItemInfo(NetworkItem item, string receiverGame, string senderGame, IItemInfoResolver itemInfoResolver, 
+			IPlayerHelper players, PlayerInfo player) 
 			: base(item, receiverGame, senderGame, itemInfoResolver, player)
 		{
+			PlayerInfo activePlayer = players.ActivePlayer;
+			IsRelatedToActivePlayer = player == activePlayer
+				|| (player?.GetGroupMembers(players)?.Contains(activePlayer) ?? false);
 		}
 	}
 }


### PR DESCRIPTION
Well, this has been discussed already what the issue is, in short IsSharingGroupWith tells you if you have an itemlink in common with a real player rather than telling you if a given player is either you or an itemlink. So, this makes the following changes:

1. Implement value equality for PlayerInfo based on team and slot (I am trusting visual studio to generate a correct GetHashCode)
2. Implement `IPlayerHelper.ActivePlayer`. Since we do plenty of comparisons with active player I felt it was useful to have. Also outside of this implementation, there were a few times I wanted it for my own usage in HK.
   * This allowed the removal of ConnectionInfo from player-related packets. So I did that. All of the constructors are internal so this is non-breaking.
4. Obsolete IsSharingGroupWith - it does what it says it does but that is not a helpful thing to do. So I would advocate to remove it in the future.
5. Add GroupMembers to PlayerInfo. Annoyingly there was not a very convenient way to get these in the form of PlayerInfo at construction time, but I think all the user-facing API should deal in PlayerInfo in the future. So I just stored the raw slot list and made GetGroupMembers which handles the mapping to PlayerInfo mapping provided a player helper. I would advocate a similar mapping for the Groups (NetworkSlot) in the future 
6. Correct the implementation of IsRelatedToActivePlayer for log messages using `Player.GetGroupMembers(playerHelper).Contains(playerHelper.ActivePlayer)` or similar (which now works because of value equality on PlayerInfo)
7. Add IsRelatedToActivePlayer to ScoutedItemInfo. My understanding is that normal ItemInfos should always be related to the active player since they are only received items.
    * I had some doubt whether this should be included in serializable item infos so it is intentionally omitted for now, let me know your thoughts on this
9. Updated unit tests according to the refactorings done
10. Added new unit tests for IsRelatedToActivePlayer for both log messages and scouted items