### PR TITLE
Update actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -43,7 +43,7 @@ jobs:
       run: dotnet test Archipelago.MultiClient.Net.Tests/bin/Release/net48/Archipelago.MultiClient.Net.Tests.dll -l "trx;LogFileName=TestResults_standard20.trx"
        
     - name: Upload Test Results
-      uses: actions/upload-artifact@v2.3.1
+      uses: actions/upload-artifact@v4
       with:
         name: TestResults
         path: TestResults/*.trx


### PR DESCRIPTION
Unclear if this will break the test report workflow, it appears that it can support artifacts created by v4 though.