### PR TITLE
Palette-based coloring support and ColorUtils implementation

### DIFF
--- a/Archipelago.MultiClient.Net/Colors/BuiltInPalettes.cs
+++ b/Archipelago.MultiClient.Net/Colors/BuiltInPalettes.cs
@@ -3,8 +3,14 @@ using System.Collections.Generic;
 
 namespace Archipelago.MultiClient.Net.Colors
 {
+	/// <summary>
+	/// Contains built-in palettes for color handling
+	/// </summary>
 	public static class BuiltInPalettes
 	{
+		/// <summary>
+		/// Default dark palette based on terminal colors
+		/// </summary>
 		public static readonly Palette<Color> Dark = new Palette<Color>(Color.White, new Dictionary<PaletteColor, Color>()
 		{
 			[PaletteColor.White] = Color.White,

--- a/Archipelago.MultiClient.Net/Colors/BuiltInPalettes.cs
+++ b/Archipelago.MultiClient.Net/Colors/BuiltInPalettes.cs
@@ -1,0 +1,23 @@
+﻿using Archipelago.MultiClient.Net.Models;
+using System.Collections.Generic;
+
+namespace Archipelago.MultiClient.Net.Colors
+{
+	public static class BuiltInPalettes
+	{
+		public static readonly Palette<Color> Dark = new Palette<Color>(Color.White, new Dictionary<PaletteColor, Color>()
+		{
+			[PaletteColor.White] = Color.White,
+			[PaletteColor.Black] = Color.Black,
+			[PaletteColor.Red] = Color.Red,
+			[PaletteColor.Green] = Color.Green,
+			[PaletteColor.Blue] = Color.Blue,
+			[PaletteColor.Cyan] = Color.Cyan,
+			[PaletteColor.Magenta] = Color.Magenta,
+			[PaletteColor.Yellow] = Color.Yellow,
+			[PaletteColor.SlateBlue] = Color.SlateBlue,
+			[PaletteColor.Salmon] = Color.Salmon,
+			[PaletteColor.Plum] = Color.Plum,
+		});
+	}
+}

--- a/Archipelago.MultiClient.Net/Colors/ColorUtils.cs
+++ b/Archipelago.MultiClient.Net/Colors/ColorUtils.cs
@@ -1,10 +1,28 @@
 ﻿using Archipelago.MultiClient.Net.Enums;
+using Archipelago.MultiClient.Net.Helpers;
+using Archipelago.MultiClient.Net.Models;
 
 namespace Archipelago.MultiClient.Net.Colors
 {
+	/// <summary>
+	/// Static utilities for getting the appropriate palette color from various protocol-provided information
+	/// </summary>
 	public static class ColorUtils
 	{
-		public static PaletteColor? GetMessagePartColor(JsonMessagePartColor color)
+		/// <summary>
+		/// The color to be used to represent the currently connected player
+		/// </summary>
+		public const PaletteColor ActivePlayerColor = PaletteColor.Magenta;
+		/// <summary>
+		/// The color to be used to represent any player other the currently connected player
+		/// </summary>
+		public const PaletteColor NonActivePlayerColor = PaletteColor.Yellow;
+
+		/// <summary>
+		/// Gets the palette color corresponding to a JsonMessagePartColor.
+		/// </summary>
+		/// <returns>The corresponding palette color, or null if not specified</returns>
+		public static PaletteColor? GetColor(JsonMessagePartColor color)
 		{
 			switch (color)
 			{
@@ -37,7 +55,11 @@ namespace Archipelago.MultiClient.Net.Colors
 			}
 		}
 
-		public static PaletteColor? GetHintColor(HintStatus status)
+		/// <summary>
+		/// Gets the palette color corresponding to a HintStatus.
+		/// </summary>
+		/// <returns>The corresponding palette color, or null if not specified</returns>
+		public static PaletteColor? GetColor(HintStatus status)
 		{
 			switch (status)
 			{
@@ -54,7 +76,20 @@ namespace Archipelago.MultiClient.Net.Colors
 			}
 		}
 
-		public static PaletteColor GetItemColor(ItemFlags flags)
+		/// <summary>
+		/// Gets the palette color corresponding to a Hint's status.
+		/// </summary>
+		/// <returns>The corresponding palette color, or null if not specified</returns>
+		public static PaletteColor? GetColor(Hint hint)
+		{
+			return GetColor(hint.Status);
+		}
+
+		/// <summary>
+		/// Gets the palette color corresponding to an ItemFlags.
+		/// </summary>
+		/// <returns>The corresponding palette color, or null if not specified</returns>
+		public static PaletteColor? GetColor(ItemFlags flags)
 		{
 			if (HasFlag(flags, ItemFlags.Advancement))
 				return PaletteColor.Plum;
@@ -66,12 +101,23 @@ namespace Archipelago.MultiClient.Net.Colors
 			return PaletteColor.Cyan;
 		}
 
-		public static PaletteColor? GetPlayerColor(bool isActivePlayer)
+		/// <summary>
+		/// Gets the palette color corresponding to an ItemInfo's flags.
+		/// </summary>
+		/// <returns>The corresponding palette color, or null if not specified</returns>
+		public static PaletteColor? GetColor(ItemInfo item)
 		{
-			if (isActivePlayer)
-				return PaletteColor.Magenta;
+			return GetColor(item.Flags);
+		}
 
-			return PaletteColor.Yellow;
+		/// <summary>
+		/// Gets the palette color corresponding to a PlayerInfo.
+		/// </summary>
+		/// <returns>The corresponding palette color, or null if not specified</returns>
+		public static PaletteColor? GetColor(PlayerInfo player, IConnectionInfoProvider connectionInfo)
+		{
+			bool isActivePlayer = player.Slot == connectionInfo.Slot;
+			return isActivePlayer ? ActivePlayerColor : NonActivePlayerColor;
 		}
 
 		static bool HasFlag(ItemFlags flags, ItemFlags flag) =>

--- a/Archipelago.MultiClient.Net/Colors/ColorUtils.cs
+++ b/Archipelago.MultiClient.Net/Colors/ColorUtils.cs
@@ -1,0 +1,84 @@
+﻿using Archipelago.MultiClient.Net.Enums;
+
+namespace Archipelago.MultiClient.Net.Colors
+{
+	public static class ColorUtils
+	{
+		public static PaletteColor? GetMessagePartColor(JsonMessagePartColor color)
+		{
+			switch (color)
+			{
+				case JsonMessagePartColor.Red:
+				case JsonMessagePartColor.RedBg:
+					return PaletteColor.Red;
+				case JsonMessagePartColor.Green:
+				case JsonMessagePartColor.GreenBg:
+					return PaletteColor.Green;
+				case JsonMessagePartColor.Yellow:
+				case JsonMessagePartColor.YellowBg:
+					return PaletteColor.Yellow;
+				case JsonMessagePartColor.Blue:
+				case JsonMessagePartColor.BlueBg:
+					return PaletteColor.Blue;
+				case JsonMessagePartColor.Magenta:
+				case JsonMessagePartColor.MagentaBg:
+					return PaletteColor.Magenta;
+				case JsonMessagePartColor.Cyan:
+				case JsonMessagePartColor.CyanBg:
+					return PaletteColor.Cyan;
+				case JsonMessagePartColor.Black:
+				case JsonMessagePartColor.BlackBg:
+					return PaletteColor.Black;
+				case JsonMessagePartColor.White:
+				case JsonMessagePartColor.WhiteBg:
+					return PaletteColor.White;
+				default:
+					return null;
+			}
+		}
+
+		public static PaletteColor? GetHintColor(HintStatus status)
+		{
+			switch (status)
+			{
+				case HintStatus.Found:
+					return PaletteColor.Green;
+				case HintStatus.NoPriority:
+					return PaletteColor.SlateBlue;
+				case HintStatus.Avoid:
+					return PaletteColor.Salmon;
+				case HintStatus.Priority:
+					return PaletteColor.Plum;
+				default:
+					return null;
+			}
+		}
+
+		public static PaletteColor GetItemColor(ItemFlags flags)
+		{
+			if (HasFlag(flags, ItemFlags.Advancement))
+				return PaletteColor.Plum;
+			if (HasFlag(flags, ItemFlags.NeverExclude))
+				return PaletteColor.SlateBlue;
+			if (HasFlag(flags, ItemFlags.Trap))
+				return PaletteColor.Salmon;
+
+			return PaletteColor.Cyan;
+		}
+
+		public static PaletteColor? GetPlayerColor(bool isActivePlayer)
+		{
+			if (isActivePlayer)
+				return PaletteColor.Magenta;
+
+			return PaletteColor.Yellow;
+		}
+
+		static bool HasFlag(ItemFlags flags, ItemFlags flag) =>
+#if NET35
+			(flags & flag) > 0;
+#else
+			flags.HasFlag(flag);
+#endif
+	}
+}

--- a/Archipelago.MultiClient.Net/Colors/Palette.cs
+++ b/Archipelago.MultiClient.Net/Colors/Palette.cs
@@ -3,16 +3,30 @@ using System.Collections.Generic;
 
 namespace Archipelago.MultiClient.Net.Colors
 {
-	// this implementation with a default color allows partial implementations for custom palettes,
-	// as well as the ability to add new PaletteColors without breaking any palettes - if you had
-	// to specify all palette colors to create a palette, the addition of a new color is breaking
-	// in both source and binary, while this is neither.
+	/// <summary>
+	/// Palette/theme support for client colors
+	/// </summary>
+	/// <typeparam name="T">
+	/// The type of actual color in the palette, typically an engine- or framework-specific Color struct
+	/// </typeparam>
 	public class Palette<T>
 	{
-		private Dictionary<PaletteColor, T> palette;
+		private readonly Dictionary<PaletteColor, T> palette;
 
+		/// <summary>
+		/// The default color to use in the palette when color is not specified, or the requested color is not
+		/// in the palette
+		/// </summary>
 		public T DefaultColor { get; private set; }
 
+		/// <summary>
+		/// Retrieves a color from the palette
+		/// </summary>
+		/// <param name="color">The palette color to look up</param>
+		/// <returns>
+		/// The requested color. Returns the default color if the requested color was null or
+		/// not defined in this palette.
+		/// </returns>
 		public T this[PaletteColor? color]
 		{
 			get
@@ -25,13 +39,25 @@ namespace Archipelago.MultiClient.Net.Colors
 			}
 		}
 
+		/// <summary>
+		/// Creates a custom palette
+		/// </summary>
+		/// <param name="defaultColor">The default color for the palette</param>
+		/// <param name="palette">
+		/// The colors in the palette. Note that this does not need to define a mapping for every
+		/// PaletteColor if it is not desired.
+		/// </param>
 		public Palette(T defaultColor, Dictionary<PaletteColor, T> palette)
 		{
 			this.DefaultColor = defaultColor;
 			this.palette = new Dictionary<PaletteColor, T>(palette);
 		}
 
-		// allows transforming an existing palette to a new data type (the use case treble mentioned)
+		/// <summary>
+		/// Creates a copy of this palette with all values transformed to another type
+		/// </summary>
+		/// <typeparam name="U">The desired color type for the new palette</typeparam>
+		/// <param name="transform">A transformation function to convert to the new type</param>
 		public Palette<U> Transform<U>(Func<T, U> transform)
 		{
 			U newDefault = transform(DefaultColor);
@@ -43,7 +69,11 @@ namespace Archipelago.MultiClient.Net.Colors
 			return new Palette<U>(newDefault, newPalette);
 		}
 
-		// allows overriding part of a palette, for use cases like "I like this palette but this one color is a problem to display"
+		/// <summary>
+		/// Creates a copy of this palette with the specified colors replaced
+		/// </summary>
+		/// <param name="newDefault">The new default color</param>
+		/// <param name="paletteEdits">A mapping specifying colors to replace</param>
 		public Palette<T> Edit(T newDefault, Dictionary<PaletteColor, T> paletteEdits)
 		{
 			Dictionary<PaletteColor, T> newPalette = new Dictionary<PaletteColor, T>(palette);
@@ -54,7 +84,11 @@ namespace Archipelago.MultiClient.Net.Colors
 			return new Palette<T>(newDefault, newPalette);
 		}
 
-		// convenience overload of above preserving default color
+		/// <summary>
+		/// Creates a copy of this palette with the specified colors replaced. The default color
+		/// is preserved.
+		/// </summary>
+		/// <param name="paletteEdits">A mapping specifying colors to replace</param>
 		public Palette<T> Edit(Dictionary<PaletteColor, T> paletteEdits)
 		{
 			return Edit(DefaultColor, paletteEdits);

--- a/Archipelago.MultiClient.Net/Colors/Palette.cs
+++ b/Archipelago.MultiClient.Net/Colors/Palette.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Archipelago.MultiClient.Net.Colors
+{
+	// this implementation with a default color allows partial implementations for custom palettes,
+	// as well as the ability to add new PaletteColors without breaking any palettes - if you had
+	// to specify all palette colors to create a palette, the addition of a new color is breaking
+	// in both source and binary, while this is neither.
+	public class Palette<T>
+	{
+		private Dictionary<PaletteColor, T> palette;
+
+		public T DefaultColor { get; private set; }
+
+		public T this[PaletteColor? color]
+		{
+			get
+			{
+				if (color.HasValue && palette.TryGetValue(color.Value, out T result))
+				{
+					return result;
+				}
+				return DefaultColor;
+			}
+		}
+
+		public Palette(T defaultColor, Dictionary<PaletteColor, T> palette)
+		{
+			this.DefaultColor = defaultColor;
+			this.palette = new Dictionary<PaletteColor, T>(palette);
+		}
+
+		// allows transforming an existing palette to a new data type (the use case treble mentioned)
+		public Palette<U> Transform<U>(Func<T, U> transform)
+		{
+			U newDefault = transform(DefaultColor);
+			Dictionary<PaletteColor, U> newPalette = new Dictionary<PaletteColor, U>(palette.Count);
+			foreach (KeyValuePair<PaletteColor, T> kv in palette)
+			{
+				newPalette[kv.Key] = transform(kv.Value);
+			}
+			return new Palette<U>(newDefault, newPalette);
+		}
+
+		// allows overriding part of a palette, for use cases like "I like this palette but this one color is a problem to display"
+		public Palette<T> Edit(T newDefault, Dictionary<PaletteColor, T> paletteEdits)
+		{
+			Dictionary<PaletteColor, T> newPalette = new Dictionary<PaletteColor, T>(palette);
+			foreach (KeyValuePair<PaletteColor, T> kv in paletteEdits)
+			{
+				newPalette[kv.Key] = kv.Value;
+			}
+			return new Palette<T>(newDefault, newPalette);
+		}
+
+		// convenience overload of above preserving default color
+		public Palette<T> Edit(Dictionary<PaletteColor, T> paletteEdits)
+		{
+			return Edit(DefaultColor, paletteEdits);
+		}
+	}
+}

--- a/Archipelago.MultiClient.Net/Colors/PaletteColor.cs
+++ b/Archipelago.MultiClient.Net/Colors/PaletteColor.cs
@@ -1,5 +1,8 @@
 ﻿namespace Archipelago.MultiClient.Net.Colors
 {
+	/// <summary>
+	/// Colors used in client palettes; some by protocol and some by convention.
+	/// </summary>
 	public enum PaletteColor
 	{
 		White,

--- a/Archipelago.MultiClient.Net/Colors/PaletteColor.cs
+++ b/Archipelago.MultiClient.Net/Colors/PaletteColor.cs
@@ -1,0 +1,17 @@
+﻿namespace Archipelago.MultiClient.Net.Colors
+{
+	public enum PaletteColor
+	{
+		White,
+		Black,
+		Red,
+		Green,
+		Blue,
+		Cyan,
+		Magenta,
+		Yellow,
+		SlateBlue,
+		Salmon,
+		Plum
+	}
+}

--- a/Archipelago.MultiClient.Net/MessageLog/Parts/EntranceMessagePart.cs
+++ b/Archipelago.MultiClient.Net/MessageLog/Parts/EntranceMessagePart.cs
@@ -8,7 +8,7 @@ namespace Archipelago.MultiClient.Net.MessageLog.Parts
 	/// <seealso cref="T:Archipelago.MultiClient.Net.MessageLog.Parts.MessagePart"/>
 	public class EntranceMessagePart : MessagePart
 	{
-		internal EntranceMessagePart(JsonMessagePart messagePart) : base(MessagePartType.Entrance, messagePart, Color.Blue)
+		internal EntranceMessagePart(JsonMessagePart messagePart) : base(MessagePartType.Entrance, messagePart, Colors.PaletteColor.Blue)
 		{
 			Text = messagePart.Text;
 		}

--- a/Archipelago.MultiClient.Net/MessageLog/Parts/HintStatusMessagePart.cs
+++ b/Archipelago.MultiClient.Net/MessageLog/Parts/HintStatusMessagePart.cs
@@ -15,7 +15,7 @@ namespace Archipelago.MultiClient.Net.MessageLog.Parts
 
 			if (messagePart.HintStatus.HasValue)
 			{
-				PaletteColor = ColorUtils.GetHintColor(messagePart.HintStatus.Value);
+				PaletteColor = ColorUtils.GetColor(messagePart.HintStatus.Value);
 			}
 		}
 	}

--- a/Archipelago.MultiClient.Net/MessageLog/Parts/HintStatusMessagePart.cs
+++ b/Archipelago.MultiClient.Net/MessageLog/Parts/HintStatusMessagePart.cs
@@ -1,4 +1,4 @@
-﻿using Archipelago.MultiClient.Net.Enums;
+﻿using Archipelago.MultiClient.Net.Colors;
 using Archipelago.MultiClient.Net.Models;
 
 namespace Archipelago.MultiClient.Net.MessageLog.Parts
@@ -13,23 +13,9 @@ namespace Archipelago.MultiClient.Net.MessageLog.Parts
 		{
 			Text = messagePart.Text;
 
-			switch (messagePart.HintStatus)
+			if (messagePart.HintStatus.HasValue)
 			{
-				case HintStatus.Found:
-					Color = Color.Green;
-					break;
-				case HintStatus.Unspecified:
-					Color = Color.White;
-					break;
-				case HintStatus.NoPriority:
-					Color = Color.SlateBlue;
-					break;
-				case HintStatus.Avoid:
-					Color = Color.Salmon;
-					break;
-				case HintStatus.Priority:
-					Color = Color.Plum;
-					break;
+				PaletteColor = ColorUtils.GetHintColor(messagePart.HintStatus.Value);
 			}
 		}
 	}

--- a/Archipelago.MultiClient.Net/MessageLog/Parts/ItemMessagePart.cs
+++ b/Archipelago.MultiClient.Net/MessageLog/Parts/ItemMessagePart.cs
@@ -1,4 +1,5 @@
-﻿using Archipelago.MultiClient.Net.DataPackage;
+﻿using Archipelago.MultiClient.Net.Colors;
+using Archipelago.MultiClient.Net.DataPackage;
 using Archipelago.MultiClient.Net.Enums;
 using Archipelago.MultiClient.Net.Helpers;
 using Archipelago.MultiClient.Net.Models;
@@ -29,7 +30,7 @@ namespace Archipelago.MultiClient.Net.MessageLog.Parts
 		internal ItemMessagePart(IPlayerHelper players, IItemInfoResolver items, JsonMessagePart part) : base(MessagePartType.Item, part)
 		{
 			Flags = part.Flags ?? ItemFlags.None;
-			Color = GetColor(Flags);
+			PaletteColor = ColorUtils.GetItemColor(Flags);
 			Player = part.Player ?? 0;
 
 			var game = (players.GetPlayerInfo(Player) ?? new PlayerInfo()).Game;
@@ -46,24 +47,5 @@ namespace Archipelago.MultiClient.Net.MessageLog.Parts
 					break;
 			}
 		}
-
-		static Color GetColor(ItemFlags flags)
-		{
-			if (HasFlag(flags, ItemFlags.Advancement))
-				return Color.Plum;
-			if (HasFlag(flags, ItemFlags.NeverExclude))
-				return Color.SlateBlue;
-			if (HasFlag(flags, ItemFlags.Trap))
-				return Color.Salmon;
-
-			return Color.Cyan;
-		}
-
-		static bool HasFlag(ItemFlags flags, ItemFlags flag) =>
-#if NET35
-			(flags & flag) > 0;
-#else
-            flags.HasFlag(flag);
-#endif
 	}
 }

--- a/Archipelago.MultiClient.Net/MessageLog/Parts/ItemMessagePart.cs
+++ b/Archipelago.MultiClient.Net/MessageLog/Parts/ItemMessagePart.cs
@@ -30,7 +30,7 @@ namespace Archipelago.MultiClient.Net.MessageLog.Parts
 		internal ItemMessagePart(IPlayerHelper players, IItemInfoResolver items, JsonMessagePart part) : base(MessagePartType.Item, part)
 		{
 			Flags = part.Flags ?? ItemFlags.None;
-			PaletteColor = ColorUtils.GetItemColor(Flags);
+			PaletteColor = ColorUtils.GetColor(Flags);
 			Player = part.Player ?? 0;
 
 			var game = (players.GetPlayerInfo(Player) ?? new PlayerInfo()).Game;

--- a/Archipelago.MultiClient.Net/MessageLog/Parts/LocationMessagePart.cs
+++ b/Archipelago.MultiClient.Net/MessageLog/Parts/LocationMessagePart.cs
@@ -22,7 +22,7 @@ namespace Archipelago.MultiClient.Net.MessageLog.Parts
 		public int Player { get; }
 
 		internal LocationMessagePart(IPlayerHelper players, IItemInfoResolver itemInfoResolver, JsonMessagePart part) 
-			: base(MessagePartType.Location, part, Color.Green)
+			: base(MessagePartType.Location, part, Colors.PaletteColor.Green)
 		{
 			Player = part.Player ?? 0;
 

--- a/Archipelago.MultiClient.Net/MessageLog/Parts/MessagePart.cs
+++ b/Archipelago.MultiClient.Net/MessageLog/Parts/MessagePart.cs
@@ -1,4 +1,5 @@
-﻿using Archipelago.MultiClient.Net.Enums;
+﻿using Archipelago.MultiClient.Net.Colors;
+using Archipelago.MultiClient.Net.Enums;
 using Archipelago.MultiClient.Net.Models;
 
 namespace Archipelago.MultiClient.Net.MessageLog.Parts
@@ -21,65 +22,36 @@ namespace Archipelago.MultiClient.Net.MessageLog.Parts
 		/// <summary>
 		/// The specified or default color for this message part
 		/// </summary>
-		public Color Color { get; internal set; }
+		public Color Color => GetColor(BuiltInPalettes.Dark);
+
+		public PaletteColor? PaletteColor { get; protected set; }
 
 		/// <summary>
 		/// The specified background color for this message part
 		/// </summary>
 		public bool IsBackgroundColor { get; internal set; }
 
-		internal MessagePart(MessagePartType type, JsonMessagePart messagePart, Color? color = null)
+		internal MessagePart(MessagePartType type, JsonMessagePart messagePart, PaletteColor? color = null)
 		{
 			Type = type;
 			Text = messagePart.Text;
 
 			if (color.HasValue)
 			{
-				Color = color.Value;
+				PaletteColor = color.Value;
 			}
 			else if (messagePart.Color.HasValue)
 			{
-				Color = GetColor(messagePart.Color.Value);
+				PaletteColor = ColorUtils.GetMessagePartColor(messagePart.Color.Value);
 				IsBackgroundColor = messagePart.Color.Value >= JsonMessagePartColor.BlackBg;
 			}
 			else
 			{
-				Color = Color.White;
+				PaletteColor = null;
 			}
 		}
 
-		static Color GetColor(JsonMessagePartColor color)
-		{
-			switch (color)
-			{
-				case JsonMessagePartColor.Red:
-				case JsonMessagePartColor.RedBg:
-					return Color.Red;
-				case JsonMessagePartColor.Green:
-				case JsonMessagePartColor.GreenBg:
-					return Color.Green;
-				case JsonMessagePartColor.Yellow:
-				case JsonMessagePartColor.YellowBg:
-					return Color.Yellow;
-				case JsonMessagePartColor.Blue:
-				case JsonMessagePartColor.BlueBg:
-					return Color.Blue;
-				case JsonMessagePartColor.Magenta:
-				case JsonMessagePartColor.MagentaBg:
-					return Color.Magenta;
-				case JsonMessagePartColor.Cyan:
-				case JsonMessagePartColor.CyanBg:
-					return Color.Cyan;
-				case JsonMessagePartColor.Black:
-				case JsonMessagePartColor.BlackBg:
-					return Color.Black;
-				case JsonMessagePartColor.White:
-				case JsonMessagePartColor.WhiteBg:
-					return Color.White;
-				default:
-					return Color.White;
-			}
-		}
+		public T GetColor<T>(Palette<T> palette) => palette[PaletteColor];
 
 		/// <summary>
 		/// The text to display of this message part

--- a/Archipelago.MultiClient.Net/MessageLog/Parts/MessagePart.cs
+++ b/Archipelago.MultiClient.Net/MessageLog/Parts/MessagePart.cs
@@ -20,14 +20,17 @@ namespace Archipelago.MultiClient.Net.MessageLog.Parts
 		public MessagePartType Type { get; internal set; }
 
 		/// <summary>
-		/// The specified or default color for this message part
+		/// The color corresponding to <see cref="PaletteColor"/> in the built-in dark palette.
 		/// </summary>
 		public Color Color => GetColor(BuiltInPalettes.Dark);
 
+		/// <summary>
+		/// The specified color for this message part, or null if not specified.
+		/// </summary>
 		public PaletteColor? PaletteColor { get; protected set; }
 
 		/// <summary>
-		/// The specified background color for this message part
+		/// Whether this message part's color is intended to represent a background color
 		/// </summary>
 		public bool IsBackgroundColor { get; internal set; }
 
@@ -42,7 +45,7 @@ namespace Archipelago.MultiClient.Net.MessageLog.Parts
 			}
 			else if (messagePart.Color.HasValue)
 			{
-				PaletteColor = ColorUtils.GetMessagePartColor(messagePart.Color.Value);
+				PaletteColor = ColorUtils.GetColor(messagePart.Color.Value);
 				IsBackgroundColor = messagePart.Color.Value >= JsonMessagePartColor.BlackBg;
 			}
 			else
@@ -51,6 +54,10 @@ namespace Archipelago.MultiClient.Net.MessageLog.Parts
 			}
 		}
 
+		/// <summary>
+		/// Gets the color corresponding to <see cref="PaletteColor"/> in the specified palette.
+		/// </summary>
+		/// <param name="palette">The palette to retrieve the color from</param>
 		public T GetColor<T>(Palette<T> palette) => palette[PaletteColor];
 
 		/// <summary>

--- a/Archipelago.MultiClient.Net/MessageLog/Parts/PlayerMessagePart.cs
+++ b/Archipelago.MultiClient.Net/MessageLog/Parts/PlayerMessagePart.cs
@@ -30,7 +30,7 @@ namespace Archipelago.MultiClient.Net.MessageLog.Parts
 					break;
 			}
 
-			PaletteColor = ColorUtils.GetPlayerColor(IsActivePlayer);
+			PaletteColor = IsActivePlayer ? ColorUtils.ActivePlayerColor : ColorUtils.NonActivePlayerColor;
 		}
 	}
 }

--- a/Archipelago.MultiClient.Net/MessageLog/Parts/PlayerMessagePart.cs
+++ b/Archipelago.MultiClient.Net/MessageLog/Parts/PlayerMessagePart.cs
@@ -1,4 +1,5 @@
-﻿using Archipelago.MultiClient.Net.Enums;
+﻿using Archipelago.MultiClient.Net.Colors;
+using Archipelago.MultiClient.Net.Enums;
 using Archipelago.MultiClient.Net.Helpers;
 using Archipelago.MultiClient.Net.Models;
 
@@ -29,15 +30,7 @@ namespace Archipelago.MultiClient.Net.MessageLog.Parts
 					break;
 			}
 
-			Color = GetColor(IsActivePlayer);
-		}
-
-		static Color GetColor(bool isActivePlayer)
-		{
-			if (isActivePlayer)
-				return Color.Magenta;
-
-			return Color.Yellow;
+			PaletteColor = ColorUtils.GetPlayerColor(IsActivePlayer);
 		}
 	}
 }

--- a/Archipelago.MultiClient.Net/Models/Color.cs
+++ b/Archipelago.MultiClient.Net/Models/Color.cs
@@ -2,12 +2,14 @@
 
 namespace Archipelago.MultiClient.Net.Models
 {
-    /// <summary>
-    /// Polyfill for System.Drawing.Color for games on runtimes which do not supply a `System.Drawing.dll`.
-    /// Not focused on memory or computation efficiency, we just need something that works reasonably well.
-    /// Transparency/alpha channel is not handled.
-    /// </summary>
-    public struct Color : IEquatable<Color>
+	// todo - move this to colors namespace at the next breaking update
+
+	/// <summary>
+	/// Polyfill for System.Drawing.Color for games on runtimes which do not supply a `System.Drawing.dll`.
+	/// Not focused on memory or computation efficiency, we just need something that works reasonably well.
+	/// Transparency/alpha channel is not handled.
+	/// </summary>
+	public struct Color : IEquatable<Color>
     {
 	    /// <summary>
 	    /// Predefined Archipelago Color Red (used for not found hints)


### PR DESCRIPTION
Adds support for palette-based coloring to allow custom colors and color types and migrates message log coloring to route via the built-in dark palette. All the message parts GetColor have been moved to a static ColorUtils so they can be used without need for a session.

A couple notable things:
* Palettes can be partially specified; any colors not specified will use the default color specified for the palette. This is helpful for some custom palette use cases as well as prevents breaks by adding new palette colors
* There is now a meaningful difference between "white" and "not specified" and the GetColor overloads have been updated accordingly (note that the dark palette is white by default so no functional change should be taking place here)
* The color can be accessed directly from the message part using `GetColor(Palette<T>)` or from the Palette itself through the `this[PaletteColor?]` indexer. The change is completely backwards compatible by routing the `Color` property through `GetColor(BuiltInPalettes.Dark)`.

Other thoughts and usage remarks are commented in, to be cleaned up if this moves forward