### PR TITLE
Remove Task.Delay in PollingLoop since ReadMessageAsync is blocking anyway

### DIFF
--- a/Archipelago.MultiClient.Net/Helpers/BaseArchipelagoSocketHelper_system.net.websockets.cs
+++ b/Archipelago.MultiClient.Net/Helpers/BaseArchipelagoSocketHelper_system.net.websockets.cs
@@ -90,7 +90,6 @@ namespace Archipelago.MultiClient.Net.Helpers
 
                 OnMessageReceived(message);
 
-                await Task.Delay(20);
             }
         }
 


### PR DESCRIPTION
As discussed on the discord thread