### PR TITLE
Update the last modified time on any data package file that is loaded

### DIFF
--- a/Archipelago.MultiClient.Net/DataPackage/FileSystemCheckSumDataPackageProvider.cs
+++ b/Archipelago.MultiClient.Net/DataPackage/FileSystemCheckSumDataPackageProvider.cs
@@ -31,6 +31,11 @@ namespace Archipelago.MultiClient.Net.DataPackage
 			{
 				var fileText = File.ReadAllText(filePath);
 				gameData = JsonConvert.DeserializeObject<GameData>(fileText);
+
+				// Updating the file's last modified time to let the automatic data package cleanup routine in CommonClient
+				// know this file was recently used
+				File.SetLastWriteTime(filePath, DateTime.Now);
+
 				return true;
 			}
 			catch


### PR DESCRIPTION
Update the last modified time on any data package file that is loaded from the shared cache to indicate that the file should not be deleted during data package cleanup.  Related to https://github.com/ArchipelagoMW/Archipelago/pull/5234.

I ran the unit tests and they all passed. I also tried using the release version of the 4.5 dll in my client and it worked fine.