### PR TITLE
Fix UpdateConnectionOptions (flags only variant)

### DIFF
--- a/Archipelago.MultiClient.Net/Helpers/ConnectionInfoHelper.cs
+++ b/Archipelago.MultiClient.Net/Helpers/ConnectionInfoHelper.cs
@@ -121,7 +121,7 @@ namespace Archipelago.MultiClient.Net.Helpers
 		public void UpdateConnectionOptions(string[] tags) => UpdateConnectionOptions(tags, ItemsHandlingFlags);
 
         ///<inheritdoc/>
-		public void UpdateConnectionOptions(ItemsHandlingFlags itemsHandlingFlags) => UpdateConnectionOptions(Tags, ItemsHandlingFlags);
+		public void UpdateConnectionOptions(ItemsHandlingFlags itemsHandlingFlags) => UpdateConnectionOptions(Tags, itemsHandlingFlags);
 
         ///<inheritdoc/>
 		public void UpdateConnectionOptions(string[] tags, ItemsHandlingFlags itemsHandlingFlags)


### PR DESCRIPTION
Capital 'I' ItemsHandlingFlags is the property, lowercase 'i' itemshandlingflags is the parameter. Before these changes, therefore, the tags-less version of this method does not actually update those flags to the given value at all.