### PR TITLE
Request Datapackage as individual responses

### DIFF
--- a/Archipelago.MultiClient.Net.Tests/ArchipelagoSessionFixture.cs
+++ b/Archipelago.MultiClient.Net.Tests/ArchipelagoSessionFixture.cs
@@ -72,7 +72,7 @@ namespace Archipelago.MultiClient.Net.Tests
 
 			Received.InOrder(() =>
 			{
-				socket.Received().SendPacket(Arg.Any<GetDataPackagePacket>());
+				socket.Received().SendMultiplePackets(Arg.Any<GetDataPackagePacket[]>());
 				socket.Received().SendPacket(Arg.Any<ConnectPacket>());
 			});
 

--- a/Archipelago.MultiClient.Net.Tests/DataPackageFileSystemCacheFixture.cs
+++ b/Archipelago.MultiClient.Net.Tests/DataPackageFileSystemCacheFixture.cs
@@ -49,8 +49,8 @@ namespace Archipelago.MultiClient.Net.Tests
                 Games = new []{ "One" }
             });
 
-            socket.Received().SendPacket(Arg.Is<GetDataPackagePacket>(p =>
-                p.Games.Length == 1 && p.Games[0] == "One"
+            socket.Received().SendMultiplePackets(Arg.Is<GetDataPackagePacket[]>(p =>
+                p.Length == 1 && p[0].Games.Length == 1 && p[0].Games[0] == "One"
             ));
         }
 
@@ -87,7 +87,7 @@ namespace Archipelago.MultiClient.Net.Tests
 
             socket.PacketReceived += Raise.Event<ArchipelagoSocketHelperDelagates.PacketReceivedHandler>(roomInfo);
 
-            socket.DidNotReceive().SendPacket(Arg.Any<GetDataPackagePacket>());
+            socket.DidNotReceive().SendMultiplePackets(Arg.Any<GetDataPackagePacket[]>());
         }
 
 		[Test]
@@ -127,8 +127,10 @@ namespace Archipelago.MultiClient.Net.Tests
 
             socket.PacketReceived += Raise.Event<ArchipelagoSocketHelperDelagates.PacketReceivedHandler>(roomInfo);
 
-            socket.Received().SendPacket(Arg.Is<GetDataPackagePacket>(p =>
-                p.Games.Length == 2 && p.Games[0] == "Two" && p.Games[1] == "Three"
+            socket.Received().SendMultiplePackets(Arg.Is<GetDataPackagePacket[]>(p =>
+                p.Length == 2 
+                && p[0].Games.Length == 1 && p[0].Games[0] == "Two" 
+                && p[1].Games.Length == 1 && p[1].Games[0] == "Three"
             ));
         }
 
@@ -257,8 +259,8 @@ namespace Archipelago.MultiClient.Net.Tests
 
 	        socket.PacketReceived += Raise.Event<ArchipelagoSocketHelperDelagates.PacketReceivedHandler>(roomInfo);
 
-	        socket.Received().SendPacket(Arg.Is<GetDataPackagePacket>(p =>
-			    p.Games.Length == 1 && p.Games[0] == "Two"
+	        socket.Received().SendMultiplePackets(Arg.Is<GetDataPackagePacket[]>(p =>
+			    p.Length == 1 && p[0].Games.Length == 1 && p[0].Games[0] == "Two"
 			));
 		}
 

--- a/Archipelago.MultiClient.Net/DataPackage/DataPackageCache.cs
+++ b/Archipelago.MultiClient.Net/DataPackage/DataPackageCache.cs
@@ -41,10 +41,9 @@ namespace Archipelago.MultiClient.Net.DataPackage
 					var invalidated = GetCacheInvalidatedGamesByChecksum(roomInfoPacket);
 					if (invalidated.Any())
                     {
-                        socket.SendPacket(new GetDataPackagePacket
-                        {
-                            Games = invalidated.ToArray()
-                        });
+                        socket.SendMultiplePackets(
+                            invalidated.Select(game => new GetDataPackagePacket { Games = new[] { game } }).ToArray()
+                        );
                     }
                     break;
                 case DataPackagePacket packagePacket:


### PR DESCRIPTION
Requests Datapackages as individual responses, like CommonClient. I tested it with Subnautica, by deleting the local datapackage before connecting to a room with a bunch of worlds; old version, the game crashes without logged exception. New version the game connects fine and populates the datapackage folder.

Unittest changes made by LLM, didn't bother doing those by hand.